### PR TITLE
App create command in monorepo setup

### DIFF
--- a/doc/adr/0003-app-create-monorepo.md
+++ b/doc/adr/0003-app-create-monorepo.md
@@ -1,4 +1,4 @@
-# p2p promote command
+# app create - add new application to existing repository
 
 Date: 2024-08-07
 

--- a/doc/adr/0003-app-create-monorepo.md
+++ b/doc/adr/0003-app-create-monorepo.md
@@ -68,14 +68,17 @@ Once we have a bare repository, we can add new applications to it.
 ```shell
 corectl app create <app-name> <monorepo-path>/<app-name> --tenant sub-tenant-name
 ```
+or 
+```shell
+cd <monorepo-path>;
+corectl app create <app-name> --tenant sub-tenant-name
+```
 
-Changes to current implementation
-
-1. if local-path is already a git repository
-   - don't create a new github repository
-   - don't set github variables (as they already set by parent)
+1. Corectl will detect if the parent directory is a git repository and will    
+   - not create a new github repository
+   - not set github variables (as they already set by parent)
    - check if there is no local changes
-2. `tenant` should be passed to template to be rendered in Makefile
-3. `.github` folder from templates would have to be copied to root of the repository
-and all files would be prefixed with `app-name`
-
+2. `tenant` will be passed to a template to be rendered in Makefile (once we have capability to render templates 
+   with parameters)
+3. `.github/workflows` folder from templates would have to be copied to root of the repository
+and all files would be prefixed with `app-name-`

--- a/doc/adr/0003-app-create-monorepo.md
+++ b/doc/adr/0003-app-create-monorepo.md
@@ -1,0 +1,81 @@
+# p2p promote command
+
+Date: 2024-08-07
+
+## Status
+
+Accepted
+
+## Context
+
+Sometimes we deal with multiple applications in a single repository.
+We want corectl to be able to create applications in such setup. 
+
+
+## Current interface
+
+```shell
+corectl app create <app-name> [<local-path>] [flags]
+
+Flags:
+      --cplatform string       Path to local repository with core-platform configuration
+  -t, --from-template string   Template to use to create an application
+      --github-org string      Github organization your company is using
+      --github-token string    Personal GitHub token to use for GitHub authentication
+  -h, --help                   help for create
+      --nonint                 Disable interactive inputs
+      --templates string       Path to local repository with software templates
+      --tenant string          Tenant to configure for P2P
+```
+
+This results in 
+- new local git repository created in <local-path>
+- application skeleton is rendered in root of the repository
+- repository is pushed to remote
+- github repository variables are initialized
+
+## Monorepo setup
+
+To achieve multiple applications in a single repository, we need to first initialize a bare repository.
+This step is important as we need to initialize a new github repository with p2p related variables.
+
+I can see two options:
+
+### Option 1 - bare flag
+
+We could add a new flag `--bare` to the `app create` command. It would create bare repository without template skeleton being rendered.
+
+```shell
+corectl app create <app-name> [<local-path>] --bare
+```
+
+### Option 2 - monorepo template
+
+Instead of adding a new flag we can utilize templates to achieve the same result.
+I.e. we can create a new template `monorepo` and use it to create a new application.
+Monorepo template will only hold `Readme.md` file but no p2p related files.
+
+This is my favourite option as it allows us to use potentially different `monorepo` templates.
+
+```shell
+corectl app create app-name --from-template monorepo
+```
+
+### Adding applications
+
+Once we have a bare repository, we can add new applications to it.
+
+```shell
+corectl app create <app-name> <monorepo-path>/<app-name> --tenant sub-tenant-name
+```
+
+Changes to current implementation
+
+1. if local-path is already a git repository
+   - don't create a new github repository
+   - don't set github variables (as they already set by parent)
+   - check if there is no local changes
+2. `tenant` should be passed to template to be rendered in Makefile
+3. `.github` folder from templates would have to be copied to root of the repository
+and all files would be prefixed with `app-name`
+

--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -129,7 +129,7 @@ func handleMonorepo(op CreateOp, githubClient *github.Client, localRepo *git.Loc
 	}, nil
 }
 
-func createPR(name string, branchName string, githubClient *github.Client, repoFullId git.GithubRepoFullId) (*github.PullRequest, error) {
+func createPR(name string, branchName string, githubClient *github.Client, repoFullId *git.GithubRepoFullId) (*github.PullRequest, error) {
 	pullRequest, _, err := githubClient.PullRequests.Create(
 		context.Background(),
 		repoFullId.Organization(),
@@ -143,10 +143,10 @@ func createPR(name string, branchName string, githubClient *github.Client, repoF
 	return pullRequest, err
 }
 
-func getRemoteRepositoryFullId(op CreateOp, githubClient *github.Client, localRepo *git.LocalRepository) (git.GithubRepoFullId, error) {
+func getRemoteRepositoryFullId(op CreateOp, githubClient *github.Client, localRepo *git.LocalRepository) (*git.GithubRepoFullId, error) {
 	remoteRepoName, err := localRepo.GetRemoteRepoName()
 	if err != nil {
-		return git.GithubRepoFullId{}, err
+		return nil, err
 	}
 
 	githubRepo, _, err := githubClient.Repositories.Get(
@@ -155,10 +155,11 @@ func getRemoteRepositoryFullId(op CreateOp, githubClient *github.Client, localRe
 		remoteRepoName,
 	)
 	if err != nil {
-		return git.GithubRepoFullId{}, err
+		return nil, err
 	}
 
-	return git.NewGithubRepoFullId(githubRepo), nil
+	repo := git.NewGithubRepoFullId(githubRepo)
+	return &repo, nil
 }
 
 func createRemoteRepository(op CreateOp, githubClient *github.Client, localRepo *git.LocalRepository) (git.GithubRepoFullId, error) {

--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -273,7 +273,7 @@ func ValidateCreate(op CreateOp, githubClient *github.Client) error {
 	}
 
 	_, isMonorepo, err := openMonorepoMaybe(op.LocalPath)
-	if err == nil {
+	if err != nil {
 		return fmt.Errorf("checking for monorepo failed with %v", err)
 	}
 

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -431,7 +431,8 @@ var _ = Describe("Create new application", func() {
 		It("called create PR correctly", func() {
 			Expect(createPrCapture.Requests).To(HaveLen(1))
 			newPrRequest := createPrCapture.Requests[0]
-			Expect(*newPrRequest.Title).To(Equal("Add " + appName))
+			Expect(*newPrRequest.Title).To(Equal("Add new-app-name application"))
+			Expect(*newPrRequest.Body).To(Equal("Adding `new-app-name` application"))
 			Expect(*newPrRequest.Head).To(Equal("add-" + appName))
 			Expect(*newPrRequest.Base).To(Equal(git.MainBranch))
 		})

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -290,6 +290,7 @@ var _ = Describe("Create new application", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			templateToUse, err := template.FindByName(templatesLocalRepo.Path(), testdata.BlankTemplate())
+			Expect(err).NotTo(HaveOccurred())
 
 			newAppLocalPath = filepath.Join(monorepoLocalRepo.Path(), "new-app-name")
 

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -137,10 +137,14 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 	if err != nil {
 		return err
 	}
-	opts.Streams.Info("Created repository: ", createdAppResult.RepositoryFullname.HttpUrl())
+	if createdAppResult.MonorepoMode {
+		opts.Streams.Info("Added ", opts.Name, " to repository: ", createdAppResult.RepositoryFullname.HttpUrl())
+	} else {
+		opts.Streams.Info("Created repository: ", createdAppResult.RepositoryFullname.HttpUrl())
+	}
 
 	tenantUpdateResult, err := createPRWithUpdatedReposListForTenant(opts, cfg, githubClient, appTenant, createdAppResult)
-	if err != nil {
+	if err != nil && !createdAppResult.MonorepoMode {
 		return err
 	}
 

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -143,10 +143,12 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 		opts.Streams.Info("Created repository: ", createdAppResult.RepositoryFullname.HttpUrl())
 	}
 
-	//todo lkan; check if we need to create PR for monorepo
-	tenantUpdateResult, err := createPRWithUpdatedReposListForTenant(opts, cfg, githubClient, appTenant, createdAppResult)
-	if err != nil && !createdAppResult.MonorepoMode {
-		return err
+	var tenantUpdateResult tenant.CreateOrUpdateResult
+	if !createdAppResult.MonorepoMode {
+		tenantUpdateResult, err = createPRWithUpdatedReposListForTenant(opts, cfg, githubClient, appTenant, createdAppResult)
+		if err != nil {
+			return err
+		}
 	}
 
 	nextStepsMessage := fmt.Sprintf(

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -143,6 +143,7 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 		opts.Streams.Info("Created repository: ", createdAppResult.RepositoryFullname.HttpUrl())
 	}
 
+	//todo lkan; check if we need to create PR for monorepo
 	tenantUpdateResult, err := createPRWithUpdatedReposListForTenant(opts, cfg, githubClient, appTenant, createdAppResult)
 	if err != nil && !createdAppResult.MonorepoMode {
 		return err

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -32,7 +32,17 @@ func NewAppCreateCmd(cfg *config.Config) (*cobra.Command, error) {
 	var appCreateCmd = &cobra.Command{
 		Use:   "create <app-name> [<local-path>]",
 		Short: "Create new application",
-		Args:  cobra.RangeArgs(1, 2),
+		Long: `Creates new application:
+
+- create a git repository locally and initializes it with application skeleton generated from a template
+- template is rendered with arguments: {{name}}, {{tenant}}
+- create a new github repository with p2p related variables
+- create a new PR to environment repository with configuration update for the new application (if necessary)
+
+NOTE: If parent directory is an existing git repository it will add a new application to it 
+      without creating a new remote repository.
+`,
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]
 			if len(args) > 1 {
@@ -209,8 +219,17 @@ func createNewApp(
 	prodEnvs := filterEnvsByNames(cfg.P2P.Prod.DefaultEnvs.Value, existingEnvs)
 
 	fulfilledTemplate := template.FulfilledTemplate{
-		Spec:      fromTemplate,
-		Arguments: []template.Argument{},
+		Spec: fromTemplate,
+		Arguments: []template.Argument{
+			{
+				Name:  "name",
+				Value: opts.Name,
+			},
+			{
+				Name:  "tenant",
+				Value: opts.Tenant,
+			},
+		},
 	}
 
 	gitAuth := git.UrlTokenAuthMethod(cfg.GitHub.Token.Value)

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -155,6 +155,7 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 
 	nextStepsMessage := fmt.Sprintf(
 		nextStepsMessageTemplateWithoutPR,
+		createdAppResult.PRUrl,
 		createdAppResult.RepositoryFullname.ActionsHttpUrl(),
 		createdAppResult.RepositoryFullname.String(),
 		createdAppResult.RepositoryFullname.String(),
@@ -193,7 +194,10 @@ GitHub CLI commands:
   gh workflow run <workflow-id> -R %s
 `
 	nextStepsMessageTemplateWithoutPR = `
-Your application is ready to be deployed to the Core Platform!
+Note: to complete application onboarding to the Core Platform you have to first merge PR that adds this application to your repository.
+PR url: %s
+
+After the PR is merged, your application is ready to be deployed to the Core Platform!
 It will either happen with next commit or you can do it manually by triggering P2P workflow.
 To do it, use GitHub web-interface or GitHub CLI.
 Workflows link: %s

--- a/pkg/git/local_repository.go
+++ b/pkg/git/local_repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"path"
+	"strings"
 )
 
 var (
@@ -304,4 +306,12 @@ func (localRepo *LocalRepository) SetRemote(url string) error {
 		URLs: []string{url},
 	})
 	return err
+}
+func (localRepo *LocalRepository) GetRemoteRepoName() (string, error) {
+	remote, err := localRepo.repo.Remote(OriginRemote)
+	if err != nil {
+		return "", err
+	}
+	url := remote.Config().URLs[0]
+	return path.Base(strings.TrimSuffix(url, ".git")), nil
 }

--- a/pkg/testutil/httpmock/capture.go
+++ b/pkg/testutil/httpmock/capture.go
@@ -36,10 +36,14 @@ func NewCaptureHandlerWithResponseFn[REQ any](
 ) *HttpCaptureHandler[REQ] {
 	return NewCaptureHandlerWithMappingFns(
 		func(r *http.Request) REQ {
-			body, err := io.ReadAll(r.Body)
-			Expect(err).NotTo(HaveOccurred(), "couldn't read request body from http mock")
 			var req REQ
-			Expect(json.Unmarshal(body, &req)).To(Succeed(), "couldn't unmarshal http mock body as json")
+			if r.Body != nil && r.ContentLength > 0 {
+				body, err := io.ReadAll(r.Body)
+				Expect(err).NotTo(HaveOccurred(), "couldn't read request body from http mock")
+				Expect(json.Unmarshal(body, &req)).To(Succeed(), "couldn't unmarshal http mock request body as json")
+			} else {
+				req = *new(REQ)
+			}
 			return req
 		},
 		provideResponseFn,

--- a/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
@@ -1,1 +1,3 @@
 # sample extended test workflow
+{{ name }}
+{{ tenant }}

--- a/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
@@ -1,0 +1,1 @@
+# sample extended test workflow

--- a/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
@@ -1,0 +1,1 @@
+# sample fast feedback workflow

--- a/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
@@ -1,1 +1,3 @@
 # sample fast feedback workflow
+{{ name }}
+{{ tenant }}

--- a/testdata/software-templates/monorepo/README.md
+++ b/testdata/software-templates/monorepo/README.md
@@ -1,0 +1,3 @@
+# Monorepo application
+
+Test example monorepo application.

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -73,3 +73,7 @@ func ProdEnvironment() string {
 func BlankTemplate() string {
 	return "blank"
 }
+
+func Monorepo() string {
+	return "monorepo"
+}

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -1,7 +1,11 @@
 package application
 
 import (
+	"context"
 	"fmt"
+	"path/filepath"
+	"slices"
+
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/testdata"
@@ -11,10 +15,6 @@ import (
 	"github.com/google/go-github/v59/github"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/thanhpk/randstr"
-	"path/filepath"
-	"slices"
-
 	"time"
 )
 
@@ -28,11 +28,14 @@ var _ = Describe("application", Ordered, func() {
 
 		prodEnv environment.Environment
 		devEnv  environment.Environment
+
+		testRunId string
 	)
 	t := GinkgoT()
 
 	BeforeAll(func() {
 		var err error
+		testRunId = testconfig.GetTestRunId()
 		homeDir = t.TempDir()
 		corectl = testconfig.NewCorectlClient(homeDir)
 		cfg, cfgDetails, err = testsetup.InitCorectl(corectl)
@@ -62,7 +65,7 @@ var _ = Describe("application", Ordered, func() {
 		)
 
 		BeforeAll(func(ctx SpecContext) {
-			newAppName = "new-test-app-" + randstr.Hex(6)
+			newAppName = "new-test-app-" + testRunId
 			appDir = filepath.Join(homeDir, newAppName)
 			_, err := corectl.Run(
 				"application", "create", newAppName, appDir,
@@ -188,4 +191,132 @@ var _ = Describe("application", Ordered, func() {
 			Expect(prFile.GetFilename()).To(Equal("tenants/tenants/" + testconfig.Cfg.Tenant + ".yaml"))
 		}, SpecTimeout(time.Minute))
 	})
+
+	Context("create in monorepo mode", Ordered, func() {
+		var (
+			monorepoName string
+			monorepoDir  string
+			newAppName   string
+			appDir       string
+		)
+
+		BeforeAll(func(ctx SpecContext) {
+			monorepoName = "test-monorepo-" + testRunId
+			monorepoDir = filepath.Join(homeDir, monorepoName)
+
+			createMonorepoRepositoryRemoteAndLocal(githubClient, ctx, cfg, monorepoName, monorepoDir)
+
+			// Create a new app within the monorepo
+			newAppName = "new-monorepo-app-" + testRunId
+			appDir = filepath.Join(monorepoDir, newAppName)
+			_, err := corectl.Run(
+				"application", "create", newAppName, appDir,
+				"-t", testdata.BlankTemplate(),
+				"--tenant", testconfig.Cfg.Tenant,
+				"--nonint")
+			Expect(err).ToNot(HaveOccurred())
+		}, NodeTimeout(2*time.Minute))
+
+		AfterAll(func(ctx SpecContext) {
+			Expect(githubClient.Repositories.Delete(
+				ctx,
+				cfg.GitHub.Organization.Value,
+				monorepoName,
+			)).Error().NotTo(HaveOccurred())
+		}, NodeTimeout(time.Minute))
+
+		It("created a PR for the new app in the monorepo", func(ctx SpecContext) {
+			prList, _, err := githubClient.PullRequests.List(
+				ctx,
+				cfg.GitHub.Organization.Value,
+				monorepoName,
+				&github.PullRequestListOptions{
+					Head: cfg.GitHub.Organization.Value + ":add-" + newAppName,
+					Base: git.MainBranch,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prList).To(HaveLen(1))
+			Expect(prList[0]).NotTo(BeNil())
+			pr := prList[0]
+
+			Expect(pr.GetTitle()).To(Equal("Add " + newAppName + " application"))
+			Expect(pr.GetState()).To(Equal("open"))
+
+			prFiles, _, err := githubClient.PullRequests.ListFiles(
+				ctx,
+				cfg.GitHub.Organization.Value,
+				monorepoName,
+				pr.GetNumber(),
+				&github.ListOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(prFiles)).To(BeNumerically(">", 0))
+
+			// Check for specific files in the PR
+			expectedFiles := []string{
+				fmt.Sprintf("%s/README.md", newAppName),
+				fmt.Sprintf(".github/workflows/%s-fast-feedback.yaml", newAppName),
+				fmt.Sprintf(".github/workflows/%s-extended-test.yaml", newAppName),
+			}
+
+			actualFiles := make([]string, len(prFiles))
+			for i, file := range prFiles {
+				actualFiles[i] = file.GetFilename()
+			}
+
+			Expect(actualFiles).To(ConsistOf(expectedFiles))
+		}, SpecTimeout(time.Minute))
+
+		It("did not create a new repository for the app", func(ctx SpecContext) {
+			_, _, err := githubClient.Repositories.Get(
+				ctx,
+				cfg.GitHub.Organization.Value,
+				newAppName,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.(*github.ErrorResponse).Response.StatusCode).To(Equal(404))
+		}, NodeTimeout(time.Minute))
+
+		It("did not create a PR for updating tenant configuration", func(ctx SpecContext) {
+			prList, _, err := githubClient.PullRequests.List(
+				ctx,
+				cfgDetails.CPlatformRepoName.Organization(),
+				cfgDetails.CPlatformRepoName.Name(),
+				&github.PullRequestListOptions{
+					Head: cfgDetails.CPlatformRepoName.Organization() + ":" + testconfig.Cfg.Tenant + "-add-repo-" + newAppName,
+					Base: git.MainBranch,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prList).To(BeEmpty())
+		}, SpecTimeout(time.Minute))
+	})
 })
+
+func createMonorepoRepositoryRemoteAndLocal(githubClient *github.Client, ctx context.Context, cfg *config.Config, monorepoName string, monorepoDir string) {
+	_, _, err := githubClient.Repositories.Create(ctx, cfg.GitHub.Organization.Value, &github.Repository{
+		Name:       github.String(monorepoName),
+		Visibility: github.String("private"),
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	_, _, err = githubClient.Repositories.CreateFile(
+		ctx,
+		cfg.GitHub.Organization.Value,
+		monorepoName,
+		"README.md",
+		&github.RepositoryContentFileOptions{
+			Message: github.String("Initial commit"),
+			Content: []byte("# Monorepo\n\nThis is a test monorepo."),
+		},
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	_, err = git.CloneToLocalRepository(git.CloneOp{
+		URL:        fmt.Sprintf("https://github.com/%s/%s.git", cfg.GitHub.Organization.Value, monorepoName),
+		TargetPath: monorepoDir,
+		Auth:       git.UrlTokenAuthMethod(cfg.GitHub.Token.Value),
+	})
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,6 +32,8 @@ func TestSuite(t *testing.T) {
 
 var _ = BeforeSuite(func(ctx SpecContext) {
 	testRunId := randstr.String(6)
+	testconfig.SetTestRunId(testRunId)
+	fmt.Println("Test Run ID: ", testRunId)
 	tempDir := GinkgoT().TempDir()
 	githubClient := testconfig.NewGitHubClient()
 	gitAuth := git.UrlTokenAuthMethod(testconfig.Cfg.GitHubToken)

--- a/tests/integration/testconfig/run_config.go
+++ b/tests/integration/testconfig/run_config.go
@@ -1,0 +1,18 @@
+package testconfig
+
+import "sync"
+
+var (
+	TestRunId     string
+	testRunIdOnce sync.Once
+)
+
+func SetTestRunId(id string) {
+	testRunIdOnce.Do(func() {
+		TestRunId = id
+	})
+}
+
+func GetTestRunId() string {
+	return TestRunId
+}


### PR DESCRIPTION
Assuming `lukasz-app-3` is an existing repository we can add a new application like this:

```shell
cd lukasz-app-3
corectl app create lukasz-sub-app --tenant lukasz-sub-app --from-template blank
Added lukasz-sub-app to repository: https://github.com/coreeng/lukasz-app-3
                                                                                                                                       
Note: to complete application onboarding to the Core Platform you have to first merge PR that adds this application to your repository.
PR url: https://github.com/coreeng/lukasz-app-3/pull/5                                                                                 
                                                                                                                                       
After the PR is merged, your application is ready to be deployed to the Core Platform!                                                 
It will either happen with next commit or you can do it manually by triggering P2P workflow.                                           
To do it, use GitHub web-interface or GitHub CLI.                                                                                      
Workflows link: https://github.com/coreeng/lukasz-app-3/actions                                                                        
GitHub CLI commands:                                                                                                                   
  gh workflow list -R coreeng/lukasz-app-3                                                                                             
  gh workflow run <workflow-id> -R coreeng/lukasz-app-3             
```

I've added a longer help description

```shell
corectl app create -h           
Creates new application:

- create a git repository locally and initializes it with application skeleton generated from a template
- template is rendered with arguments: {{name}}, {{tenant}}
- create a new github repository with p2p related variables
- create a new PR to environment repository with configuration update for the new application (if necessary)

NOTE: If parent directory is an existing git repository it will add a new application to it 
      without creating a new remote repository.

Usage:
  corectl app create <app-name> [<local-path>] [flags]
...
```

I'm passing `tenant` and `name` to render templates so they can be used in software templates.