### PR TITLE
export env variables required to run onboarded apps p2p makefile targets

### DIFF
--- a/pkg/cmd/p2p/export/export.go
+++ b/pkg/cmd/p2p/export/export.go
@@ -19,12 +19,12 @@ type exportOpts struct {
 	streams         userio.IOStreams
 }
 
-func (eo *exportOpts) processFlags(cplatRepoPath string) (*p2p.EnvVarContext, error) {
-	argTenant, err := selector.Tenant(cplatRepoPath, eo.tenant, eo.streams)
+func (eo *exportOpts) processFlags(cPlatRepoPath string) (*p2p.EnvVarContext, error) {
+	argTenant, err := selector.Tenant(cPlatRepoPath, eo.tenant, eo.streams)
 	if err != nil {
 		return nil, err
 	}
-	argEnv, err := selector.Environment(cplatRepoPath, eo.environmentName, eo.streams)
+	argEnv, err := selector.Environment(cPlatRepoPath, eo.environmentName, argTenant.Environments, eo.streams)
 	if err != nil {
 		return nil, err
 	}
@@ -114,6 +114,7 @@ func NewP2PExportCmd(cfg *config.Config) (*cobra.Command, error) {
 		currDir,
 		"Local repository path to export variables for P2P, defaults to current exec directory",
 	)
+
 	return exportCommand, nil
 }
 

--- a/pkg/cmd/p2p/export/export.go
+++ b/pkg/cmd/p2p/export/export.go
@@ -1,0 +1,138 @@
+package export
+
+import (
+	"fmt"
+	"github.com/coreeng/corectl/pkg/cmdutil/config"
+	"github.com/coreeng/corectl/pkg/cmdutil/selector"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio"
+	"github.com/coreeng/corectl/pkg/git"
+	"github.com/coreeng/corectl/pkg/p2p"
+	"github.com/spf13/cobra"
+	"os"
+	"strings"
+)
+
+type exportOpts struct {
+	tenant          string
+	environmentName string
+	repoPath        string
+	streams         userio.IOStreams
+}
+
+func (eo *exportOpts) processFlags(cplatRepoPath string) (*p2p.EnvVarContext, error) {
+	argTenant, err := selector.Tenant(cplatRepoPath, eo.tenant, eo.streams)
+	if err != nil {
+		return nil, err
+	}
+	argEnv, err := selector.Environment(cplatRepoPath, eo.environmentName, eo.streams)
+	if err != nil {
+		return nil, err
+	}
+	argRepo, err := eo.appRepoPathSelector()
+	if err != nil {
+		return nil, err
+	}
+
+	return &p2p.EnvVarContext{Tenant: argTenant, Environment: argEnv, AppRepo: argRepo}, nil
+}
+
+func (eo *exportOpts) appRepoPathSelector() (*git.LocalRepository, error) {
+	inputRepoPath := eo.createRepoPathInputSwitch(eo.repoPath)
+	repoPathOutput, err := inputRepoPath.GetValue(eo.streams)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := git.OpenLocalRepository(repoPathOutput)
+	if err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+func (eo *exportOpts) createRepoPathInputSwitch(defaultName string) userio.InputSourceSwitch[string, string] {
+	validateFn := func(inp string) (string, error) {
+		inp = strings.TrimSpace(inp)
+		if _, err := os.Stat(inp); err != nil {
+			return "", fmt.Errorf("cannot load repo at path %s: %w", inp, err)
+		}
+		return inp, nil
+	}
+	return userio.InputSourceSwitch[string, string]{
+		DefaultValue: userio.AsZeroable(defaultName),
+		InteractivePromptFn: func() (userio.InputPrompt[string], error) {
+			return &userio.TextInput[string]{
+				Prompt:      "App repository path:",
+				Placeholder: "repoPath",
+				ValidateAndMap: func(inp string) (string, error) {
+					name, err := validateFn(inp)
+					return name, err
+				},
+			}, nil
+		},
+		ValidateAndMap: validateFn,
+		ErrMessage:     fmt.Sprintf("invalid repository path %s", defaultName),
+	}
+}
+
+func NewP2PExportCmd(cfg *config.Config) (*cobra.Command, error) {
+	opts := &exportOpts{}
+	var exportCommand = &cobra.Command{
+		Use:   "export",
+		Short: "Produce export statements for environment variables required to execute p2p targets, to automatically export in current shell run 'eval $(corectl p2p export [flags])'",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.streams = userio.NewIOStreams(
+				cmd.InOrStdin(),
+				cmd.OutOrStdout(),
+			)
+			return run(opts, &cfg.Repositories.CPlatform)
+		},
+	}
+
+	currDir, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	exportCommand.Flags().StringVarP(
+		&opts.environmentName,
+		"environment",
+		"e",
+		"",
+		"Environment to export variables for P2P",
+	)
+	exportCommand.Flags().StringVarP(
+		&opts.tenant,
+		"tenant",
+		"t",
+		"",
+		"Tenant to export variables for P2P",
+	)
+	exportCommand.Flags().StringVarP(
+		&opts.repoPath,
+		"repoPath",
+		"r",
+		currDir,
+		"Local repository path to export variables for P2P, defaults to current exec directory",
+	)
+	return exportCommand, nil
+}
+
+func run(opts *exportOpts, cplatRepoPath *config.Parameter[string]) error {
+	if _, err := config.ResetConfigRepositoryState(cplatRepoPath); err != nil {
+		return err
+	}
+	context, err := opts.processFlags(cplatRepoPath.Value)
+	if err != nil {
+		return err
+	}
+	p2pVars, err := p2p.NewP2pEnvVariables(context)
+	if err != nil {
+		return err
+	}
+	exportCmd, err := p2pVars.AsExportCmd()
+	if err != nil {
+		return err
+	}
+	opts.streams.Info(exportCmd)
+	return nil
+}

--- a/pkg/cmd/p2p/export/export_test.go
+++ b/pkg/cmd/p2p/export/export_test.go
@@ -1,0 +1,111 @@
+package export
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/coreeng/corectl/pkg/cmdutil/config"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio"
+	"github.com/coreeng/corectl/pkg/git"
+	"github.com/coreeng/corectl/pkg/p2p"
+	"github.com/coreeng/corectl/pkg/testutil/gittest"
+	"github.com/coreeng/corectl/testdata"
+	"github.com/otiai10/copy"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+var streams = userio.NewIOStreams(os.Stdin, os.Stdout)
+
+func TestRunExportPrintsEnvVarsToStdOut(t *testing.T) {
+	var output bytes.Buffer
+
+	err := run(&exportOpts{
+		tenant:          testdata.DefaultTenant(),
+		environmentName: testdata.DevEnvironment(),
+		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		streams:         userio.NewIOStreams(os.Stdin, &output),
+	}, &config.Parameter[string]{Value: testLocalRepo(t, testdata.CPlatformEnvsPath()).Path()})
+
+	assert.NoError(t, err)
+	assert.Contains(t, output.String(), "export", p2p.BaseDomain, p2p.Registry, p2p.Version, p2p.RepoPath, p2p.TenantName, p2p.Region)
+}
+
+func TestRunExportNonExistingAppRepo(t *testing.T) {
+	appRepoPath := t.TempDir()
+
+	err := run(&exportOpts{
+		tenant:          testdata.DefaultTenant(),
+		environmentName: testdata.DevEnvironment(),
+		repoPath:        appRepoPath,
+		streams:         streams,
+	}, &config.Parameter[string]{Value: testLocalRepo(t, testdata.CPlatformEnvsPath()).Path()})
+
+	assert.ErrorContains(t, err, fmt.Sprintf("repository on path %s not found: repository does not exist", appRepoPath))
+}
+
+func TestRunExportNonExistingTenant(t *testing.T) {
+	tenantName := fmt.Sprintf("%s-tenant", t.Name())
+	cPlatRepoPath := testLocalRepo(t, testdata.CPlatformEnvsPath()).Path()
+
+	err := run(&exportOpts{
+		tenant:          tenantName,
+		environmentName: testdata.DevEnvironment(),
+		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		streams:         streams,
+	}, &config.Parameter[string]{Value: cPlatRepoPath})
+
+	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s/tenants/tenants: tenant %s invalid: cannot find %s tenant, available tenants: [default-tenant parent]", cPlatRepoPath, tenantName, tenantName))
+}
+
+func TestRunExportNonExistingEnvironment(t *testing.T) {
+	envName := fmt.Sprintf("%s-env", t.Name())
+	cPlatRepoPath := testLocalRepo(t, testdata.CPlatformEnvsPath()).Path()
+
+	err := run(&exportOpts{
+		tenant:          testdata.DefaultTenant(),
+		environmentName: envName,
+		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		streams:         streams,
+	}, &config.Parameter[string]{Value: cPlatRepoPath})
+
+	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s/environments: environment %s invalid: cannot find %s environment, available envs: [dev prod]", cPlatRepoPath, envName, envName))
+}
+
+func TestRunExportCPlatformRepoNotExist(t *testing.T) {
+	err := run(&exportOpts{
+		tenant:          testdata.DefaultTenant(),
+		environmentName: testdata.DevEnvironment(),
+		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		streams:         streams,
+	}, &config.Parameter[string]{})
+
+	assert.ErrorContains(t, err, "path is not set. consider initializing corectl first:\n  corectl config init")
+}
+
+func TestRunExportCPlatRepoWithUncommitedChanges(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+	appRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+	currDir, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.NoError(t, copy.Copy(currDir, cPlatRepo.Path()))
+
+	err = run(&exportOpts{
+		tenant:          testdata.DefaultTenant(),
+		environmentName: testdata.DevEnvironment(),
+		repoPath:        appRepo.Path(),
+		streams:         streams,
+	}, &config.Parameter[string]{Value: cPlatRepo.Path()})
+
+	assert.ErrorContains(t, err, fmt.Sprintf("local changes are present in repo on path %s. consider removing it before using corectl", cPlatRepo.Path()))
+}
+
+func testLocalRepo(t *testing.T, path string) *git.LocalRepository {
+	_, repo, err := gittest.CreateBareAndLocalRepoFromDir(&gittest.CreateBareAndLocalRepoOp{
+		SourceDir:          path,
+		TargetBareRepoDir:  t.TempDir(),
+		TargetLocalRepoDir: t.TempDir(),
+	})
+	assert.NoError(t, err)
+	return repo
+}

--- a/pkg/cmd/p2p/p2p.go
+++ b/pkg/cmd/p2p/p2p.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	p2penv "github.com/coreeng/corectl/pkg/cmd/p2p/env"
+	"github.com/coreeng/corectl/pkg/cmd/p2p/export"
 	"github.com/coreeng/corectl/pkg/cmd/p2p/promote"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/spf13/cobra"
@@ -26,6 +27,12 @@ func NewP2PCmd(cfg *config.Config) (*cobra.Command, error) {
 	p2pCmd.AddCommand(p2pCommand)
 
 	p2pCommand, err = promote.NewP2PPromoteCmd()
+	if err != nil {
+		return nil, err
+	}
+	p2pCmd.AddCommand(p2pCommand)
+
+	p2pCommand, err = export.NewP2PExportCmd(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmdutil/config/repositories.go
+++ b/pkg/cmdutil/config/repositories.go
@@ -12,7 +12,7 @@ func ResetConfigRepositoryState(repositoryParam *Parameter[string]) (*git.LocalR
 	}
 	repo, err := git.OpenAndResetRepositoryState(repositoryParam.Value)
 	if errors.Is(err, git.ErrLocalChangesIsPresent) {
-		return nil, fmt.Errorf("local changes are present in %s. consider removing it before using corectl. path: %s", repositoryParam.name, repositoryParam.Value)
+		return nil, fmt.Errorf("local changes are present in repo on path %s. consider removing it before using corectl", repositoryParam.Value)
 	} else if err != nil {
 		return nil, fmt.Errorf("couldn't reset state for %s: %v. path: %s", repositoryParam.name, err, repositoryParam.Value)
 	}

--- a/pkg/cmdutil/selector/input.go
+++ b/pkg/cmdutil/selector/input.go
@@ -1,0 +1,108 @@
+package selector
+
+import (
+	"fmt"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio"
+	"github.com/coreeng/developer-platform/pkg/environment"
+	coretnt "github.com/coreeng/developer-platform/pkg/tenant"
+	"slices"
+	"strings"
+)
+
+func Tenant(cPlatRepoPath string, overrideTenantName string, streams userio.IOStreams) (*coretnt.Tenant, error) {
+	cPlatRepoPath = coretnt.DirFromCPlatformPath(cPlatRepoPath)
+	existingTenants, err := coretnt.List(cPlatRepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load tenant configuration in path %s: %w", cPlatRepoPath, err)
+	}
+	inputTenant := createTenantInput(overrideTenantName, existingTenants)
+	tenantOutput, err := inputTenant.GetValue(streams)
+	if err != nil {
+		return nil, fmt.Errorf("config repo path %s: %w", cPlatRepoPath, err)
+	}
+	return tenantOutput, nil
+}
+
+func Environment(cPlatRepoPath string, overrideEnvName string, streams userio.IOStreams) (*environment.Environment, error) {
+	cPlatRepoPath = environment.DirFromCPlatformRepoPath(cPlatRepoPath)
+	envs, err := environment.List(cPlatRepoPath)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't load environment configuration: %w", err)
+	}
+	inputEnv := createEnvInputSwitch(overrideEnvName, envs)
+	envOutput, err := inputEnv.GetValue(streams)
+	if err != nil {
+		return nil, fmt.Errorf("config repo path %s: %w", cPlatRepoPath, err)
+	}
+	return envOutput, nil
+}
+
+func createEnvInputSwitch(defaultEnv string, environments []environment.Environment) *userio.InputSourceSwitch[string, *environment.Environment] {
+	validateFn := func(env string) (*environment.Environment, error) {
+		env = strings.TrimSpace(env)
+		envIndex := slices.IndexFunc(environments, func(e environment.Environment) bool {
+			return e.Environment == env
+		})
+		if envIndex < 0 {
+			return nil, fmt.Errorf("cannot find %s environment, available envs: %v", defaultEnv, sliceMap(environments, func(e environment.Environment) string {
+				return e.Environment
+			}))
+		}
+		return &environments[envIndex], nil
+	}
+	return &userio.InputSourceSwitch[string, *environment.Environment]{
+		DefaultValue: userio.AsZeroable(defaultEnv),
+		InteractivePromptFn: func() (userio.InputPrompt[string], error) {
+			envs := make([]string, len(environments))
+			for i, t := range environments {
+				envs[i] = t.Environment
+			}
+			return &userio.SingleSelect{
+				Prompt: "Select environment to connect to:",
+				Items:  envs,
+			}, nil
+		},
+		ValidateAndMap: validateFn,
+		ErrMessage:     fmt.Sprintf("environment %s invalid", defaultEnv),
+	}
+}
+
+func createTenantInput(defaultTenant string, existingTenants []coretnt.Tenant) *userio.InputSourceSwitch[string, *coretnt.Tenant] {
+	var validateFq = func(e string) (*coretnt.Tenant, error) {
+		inpName := strings.TrimSpace(e)
+		tenantIndex := slices.IndexFunc(existingTenants, func(t coretnt.Tenant) bool {
+			return t.Name == inpName
+		})
+		if tenantIndex < 0 {
+			return nil, fmt.Errorf("cannot find %s tenant, available tenants: %v", e, sliceMap(existingTenants, func(t coretnt.Tenant) string {
+				return t.Name
+			}))
+		}
+		return &existingTenants[tenantIndex], nil
+	}
+	availableTenantNames := make([]string, len(existingTenants)+1)
+	availableTenantNames[0] = coretnt.RootName
+	for i, t := range existingTenants {
+		availableTenantNames[i+1] = t.Name
+	}
+	return &userio.InputSourceSwitch[string, *coretnt.Tenant]{
+		DefaultValue: userio.AsZeroable(defaultTenant),
+		InteractivePromptFn: func() (userio.InputPrompt[string], error) {
+			return &userio.SingleSelect{
+				Prompt: "Tenant:",
+				Items:  availableTenantNames,
+			}, nil
+		},
+		ValidateAndMap: validateFq,
+		ErrMessage:     fmt.Sprintf("tenant %s invalid", defaultTenant),
+	}
+}
+
+// apply function to each element of the slice
+func sliceMap[S ~[]E, E any](s S, f func(E) string) []string {
+	vsm := make([]string, len(s))
+	for i, v := range s {
+		vsm[i] = f(v)
+	}
+	return vsm
+}

--- a/pkg/cmdutil/selector/input_test.go
+++ b/pkg/cmdutil/selector/input_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/testutil/gittest"
 	"github.com/coreeng/corectl/testdata"
+	"github.com/coreeng/developer-platform/pkg/environment"
+	coretnt "github.com/coreeng/developer-platform/pkg/tenant"
 	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
@@ -44,26 +46,35 @@ func TestTenantSelectorInvalidCPlatRepo(t *testing.T) {
 func TestEnvironmentSelectorReturnsEnvironment(t *testing.T) {
 	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
 
-	env, err := Environment(cPlatRepo.Path(), testdata.DevEnvironment(), streams)
+	env, err := Environment(cPlatRepo.Path(), testdata.DevEnvironment(), testdata.TenantEnvs(), streams)
 
 	assert.NoError(t, err)
 	assert.Equal(t, env.Environment, testdata.DevEnvironment())
+}
+
+func TestEnvironmentSelectorFilterOnTenantEnvs(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+
+	env, err := Environment(cPlatRepo.Path(), testdata.DevEnvironment(), []string{"not-tenant-envs"}, streams)
+
+	assert.ErrorContains(t, err, fmt.Sprintf("tenant env %s doesn't exist in tenant configuration %s", testdata.DevEnvironment(), coretnt.DirFromCPlatformPath(cPlatRepo.Path())))
+	assert.Nil(t, env)
 }
 
 func TestEnvironmentSelectorNonExistingEnvironment(t *testing.T) {
 	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
 	env := fmt.Sprintf("%s-env", t.Name())
 
-	tenant, err := Environment(cPlatRepo.Path(), env, streams)
+	tenant, err := Environment(cPlatRepo.Path(), env, testdata.TenantEnvs(), streams)
 
-	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s/environments: environment %s invalid: cannot find %s environment, available envs: [dev prod]", cPlatRepo.Path(), env, env))
+	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s: environment %s invalid: cannot find %s environment, available envs: [dev prod]", environment.DirFromCPlatformRepoPath(cPlatRepo.Path()), env, env))
 	assert.Nil(t, tenant)
 }
 
 func TestEnvironmentSelectorInvalidCPlatRepo(t *testing.T) {
 	cPlatRepoPath := t.TempDir()
 
-	tenant, err := Environment(cPlatRepoPath, testdata.DevEnvironment(), streams)
+	tenant, err := Environment(cPlatRepoPath, testdata.DevEnvironment(), testdata.TenantEnvs(), streams)
 
 	assert.ErrorContains(t, err, fmt.Sprintf("couldn't load environment configuration: open %s/environments: no such file or directory", cPlatRepoPath))
 	assert.Nil(t, tenant)

--- a/pkg/cmdutil/selector/input_test.go
+++ b/pkg/cmdutil/selector/input_test.go
@@ -1,0 +1,80 @@
+package selector
+
+import (
+	"fmt"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio"
+	"github.com/coreeng/corectl/pkg/git"
+	"github.com/coreeng/corectl/pkg/testutil/gittest"
+	"github.com/coreeng/corectl/testdata"
+	"github.com/stretchr/testify/assert"
+	"os"
+	"testing"
+)
+
+var streams = userio.NewIOStreams(os.Stdin, os.Stdout)
+
+func TestTenantSelectorReturnsTenant(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+
+	tenant, err := Tenant(cPlatRepo.Path(), testdata.DefaultTenant(), streams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, tenant.Name, testdata.DefaultTenant())
+}
+
+func TestTenantSelectorNonExistingTenant(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+	tenantName := fmt.Sprintf("%s-tenant", t.Name())
+
+	tenant, err := Tenant(cPlatRepo.Path(), fmt.Sprintf("%s-tenant", t.Name()), streams)
+
+	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s/tenants/tenants: tenant %s invalid: cannot find %s tenant, available tenants: [default-tenant parent]", cPlatRepo.Path(), tenantName, tenantName))
+	assert.Nil(t, tenant)
+}
+
+func TestTenantSelectorInvalidCPlatRepo(t *testing.T) {
+	cPlatRepoPath := t.TempDir()
+
+	tenant, err := Tenant(cPlatRepoPath, testdata.DefaultTenant(), streams)
+
+	assert.ErrorContains(t, err, fmt.Sprintf("couldn't load tenant configuration in path %s/tenants/tenants: stat .: no such file or directory", cPlatRepoPath))
+	assert.Nil(t, tenant)
+}
+
+func TestEnvironmentSelectorReturnsEnvironment(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+
+	env, err := Environment(cPlatRepo.Path(), testdata.DevEnvironment(), streams)
+
+	assert.NoError(t, err)
+	assert.Equal(t, env.Environment, testdata.DevEnvironment())
+}
+
+func TestEnvironmentSelectorNonExistingEnvironment(t *testing.T) {
+	cPlatRepo := testLocalRepo(t, testdata.CPlatformEnvsPath())
+	env := fmt.Sprintf("%s-env", t.Name())
+
+	tenant, err := Environment(cPlatRepo.Path(), env, streams)
+
+	assert.ErrorContains(t, err, fmt.Sprintf("config repo path %s/environments: environment %s invalid: cannot find %s environment, available envs: [dev prod]", cPlatRepo.Path(), env, env))
+	assert.Nil(t, tenant)
+}
+
+func TestEnvironmentSelectorInvalidCPlatRepo(t *testing.T) {
+	cPlatRepoPath := t.TempDir()
+
+	tenant, err := Environment(cPlatRepoPath, testdata.DevEnvironment(), streams)
+
+	assert.ErrorContains(t, err, fmt.Sprintf("couldn't load environment configuration: open %s/environments: no such file or directory", cPlatRepoPath))
+	assert.Nil(t, tenant)
+}
+
+func testLocalRepo(t *testing.T, path string) *git.LocalRepository {
+	_, repo, err := gittest.CreateBareAndLocalRepoFromDir(&gittest.CreateBareAndLocalRepoOp{
+		SourceDir:          path,
+		TargetBareRepoDir:  t.TempDir(),
+		TargetLocalRepoDir: t.TempDir(),
+	})
+	assert.NoError(t, err)
+	return repo
+}

--- a/pkg/git/local_repository.go
+++ b/pkg/git/local_repository.go
@@ -82,7 +82,7 @@ func OpenLocalRepository(path string) (*LocalRepository, error) {
 	repository, err := git.PlainOpen(path)
 	localRepository.repo = repository
 	if err != nil {
-		return localRepository, err
+		return localRepository, fmt.Errorf("repository on path %s not found: %w", path, err)
 	}
 	worktree, err := repository.Worktree()
 	localRepository.worktree = worktree
@@ -304,4 +304,13 @@ func (localRepo *LocalRepository) SetRemote(url string) error {
 		URLs: []string{url},
 	})
 	return err
+}
+
+// HeadShortCommitHash returns short commit hash, currently no support for this feature in go-git lib (some discussions: https://github.com/src-d/go-git/issues/602)
+func (localRepo *LocalRepository) HeadShortCommitHash() (string, error) {
+	ref, err := localRepo.repo.Head()
+	if err != nil {
+		return "", err
+	}
+	return ref.Hash().String()[0:7], nil
 }

--- a/pkg/p2p/env_variables.go
+++ b/pkg/p2p/env_variables.go
@@ -1,0 +1,64 @@
+package p2p
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/coreeng/corectl/pkg/git"
+	"github.com/coreeng/developer-platform/pkg/environment"
+	coretnt "github.com/coreeng/developer-platform/pkg/tenant"
+)
+
+const (
+	BaseDomain = "BASE_DOMAIN"
+	Registry   = "REGISTRY"
+	Version    = "VERSION"
+	RepoPath   = "REPO_PATH"
+	Region     = "REGION"
+	TenantName = "TENANT_NAME"
+)
+
+type EnvVarContext struct {
+	Tenant      *coretnt.Tenant
+	Environment *environment.Environment
+	AppRepo     *git.LocalRepository
+}
+type EnvVars map[string]string
+
+func (p2pEnv *EnvVars) AsExportCmd() (string, error) {
+	s, err := p2pEnv.asKeyValString("export")
+	if err != nil {
+		return "", err
+	}
+	return s, nil
+}
+
+func (p2pEnv *EnvVars) asKeyValString(keyPrefix string) (string, error) {
+	b := new(bytes.Buffer)
+	for key, value := range *p2pEnv {
+		_, err := fmt.Fprintf(b, "%s %s=\"%s\"\n", keyPrefix, key, value)
+		if err != nil {
+			return "", fmt.Errorf("faild to convert vars map %v to string", p2pEnv)
+		}
+	}
+	return b.String(), nil
+}
+
+func NewP2pEnvVariables(context *EnvVarContext) (*EnvVars, error) {
+	var envVars = make(EnvVars)
+	envVars[TenantName] = context.Tenant.Name
+	envVars[BaseDomain] = context.Environment.GetDefaultIngressDomain().Domain
+	envVars[RepoPath] = context.AppRepo.Path()
+	switch p := context.Environment.Platform.(type) {
+	case *environment.GCPVendor:
+		envVars[Region] = p.Region
+		envVars[Registry] = fmt.Sprintf("%s-docker.pkg.dev/%s/tenant/%s", p.Region, p.ProjectId, context.Tenant.Name)
+	default:
+		return nil, fmt.Errorf("platform vendor not supported: %s", context.Environment.Platform.Type())
+	}
+	version, err := context.AppRepo.HeadShortCommitHash()
+	if err != nil {
+		return nil, err
+	}
+	envVars[Version] = version
+	return &envVars, nil
+}

--- a/pkg/p2p/env_variables_test.go
+++ b/pkg/p2p/env_variables_test.go
@@ -1,0 +1,106 @@
+package p2p
+
+import (
+	"fmt"
+	"github.com/coreeng/corectl/pkg/git"
+	"github.com/coreeng/corectl/pkg/testutil/gittest"
+	"github.com/coreeng/corectl/testdata"
+	"github.com/coreeng/developer-platform/pkg/environment"
+	coretnt "github.com/coreeng/developer-platform/pkg/tenant"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCreateEnvVarsAsMap(t *testing.T) {
+	testRepo := testLocalRepo(t)
+	tenant := newTenant(t)
+	env := newEnv(t)
+
+	vars, err := NewP2pEnvVariables(&EnvVarContext{Tenant: tenant, Environment: env, AppRepo: testRepo})
+
+	assert.NoError(t, err)
+	assert.Equal(t, vars, &EnvVars{
+		BaseDomain: env.GetDefaultIngressDomain().Domain,
+		Registry:   toRegistry(t, env.Platform.(*environment.GCPVendor), tenant.Name),
+		Version:    commitHash(t, testRepo),
+		RepoPath:   testRepo.Path(),
+		Region:     env.Platform.(*environment.GCPVendor).Region,
+		TenantName: tenant.Name})
+}
+
+func TestCreateEnvVarsReturnsVarsAsExportCmd(t *testing.T) {
+	testRepo := testLocalRepo(t)
+	tenant := newTenant(t)
+	env := newEnv(t)
+
+	vars, err := NewP2pEnvVariables(&EnvVarContext{Tenant: tenant, Environment: env, AppRepo: testRepo})
+
+	assert.NoError(t, err)
+	assert.Contains(t, asExportCmd(t, vars),
+		envVarFormat(t, BaseDomain, env.GetDefaultIngressDomain().Domain),
+		envVarFormat(t, Registry, toRegistry(t, env.Platform.(*environment.GCPVendor), tenant.Name)),
+		envVarFormat(t, Version, commitHash(t, testRepo)),
+		envVarFormat(t, RepoPath, testRepo.Path()),
+		envVarFormat(t, Region, env.Platform.(*environment.GCPVendor).Region),
+		envVarFormat(t, TenantName, tenant.Name))
+}
+
+func TestCreateEnvVarsUnsupportedPlatform(t *testing.T) {
+	env := &environment.Environment{
+		IngressDomains: []environment.Domain{{Name: "default", Domain: fmt.Sprintf("%s-domain", t.Name())}},
+		Platform: &environment.AWSVendor{
+			Vendor: environment.AWSVendorType,
+		},
+	}
+
+	_, err := NewP2pEnvVariables(&EnvVarContext{Tenant: newTenant(t), Environment: env, AppRepo: testLocalRepo(t)})
+
+	assert.ErrorContains(t, err, "platform vendor not supported: aws")
+}
+
+func newTenant(t *testing.T) *coretnt.Tenant {
+	return &coretnt.Tenant{
+		Name: fmt.Sprintf("%s-tenant", t.Name()),
+	}
+}
+
+func newEnv(t *testing.T) *environment.Environment {
+	return &environment.Environment{
+		IngressDomains: []environment.Domain{{Name: "default", Domain: fmt.Sprintf("%s-domain", t.Name())}},
+		Platform: &environment.GCPVendor{
+			Region:    fmt.Sprintf("%s-region", t.Name()),
+			ProjectId: fmt.Sprintf("%s-projId", t.Name()),
+			Vendor:    environment.GCPVendorType,
+		},
+	}
+}
+
+func testLocalRepo(t *testing.T) *git.LocalRepository {
+	_, repo, err := gittest.CreateBareAndLocalRepoFromDir(&gittest.CreateBareAndLocalRepoOp{
+		SourceDir:          testdata.CPlatformEnvsPath(),
+		TargetBareRepoDir:  t.TempDir(),
+		TargetLocalRepoDir: t.TempDir(),
+	})
+	assert.NoError(t, err)
+	return repo
+}
+
+var envVarFormat = func(t *testing.T, k, v string) string {
+	return fmt.Sprintf("export %s=\"%s\"", k, v)
+}
+
+var commitHash = func(t *testing.T, repo *git.LocalRepository) string {
+	hash, err := repo.HeadShortCommitHash()
+	assert.NoError(t, err)
+	return hash
+}
+
+var asExportCmd = func(t *testing.T, vars *EnvVars) string {
+	cmd, err := vars.AsExportCmd()
+	assert.NoError(t, err)
+	return cmd
+}
+
+var toRegistry = func(t *testing.T, vendor *environment.GCPVendor, tenantName string) string {
+	return fmt.Sprintf("%s-docker.pkg.dev/%s/tenant/%s", vendor.Region, vendor.ProjectId, tenantName)
+}

--- a/testdata/testdata.go
+++ b/testdata/testdata.go
@@ -66,6 +66,10 @@ func DevEnvironment() string {
 	return "dev"
 }
 
+func TenantEnvs() []string {
+	return []string{DevEnvironment(), ProdEnvironment()}
+}
+
 func ProdEnvironment() string {
 	return "prod"
 }

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -64,12 +64,12 @@ var _ = Describe("application", Ordered, func() {
 		BeforeAll(func(ctx SpecContext) {
 			newAppName = "new-test-app-" + randstr.Hex(6)
 			appDir = filepath.Join(homeDir, newAppName)
-			Expect(corectl.Run(
+			_, err := corectl.Run(
 				"application", "create", newAppName, appDir,
 				"-t", testdata.BlankTemplate(),
 				"--tenant", testconfig.Cfg.Tenant,
-				"--nonint",
-			)).To(Succeed())
+				"--nonint")
+			Expect(err).ToNot(HaveOccurred())
 		}, NodeTimeout(time.Minute))
 
 		AfterAll(func(ctx SpecContext) {

--- a/tests/integration/config/config.go
+++ b/tests/integration/config/config.go
@@ -134,9 +134,8 @@ var _ = Describe("config", Ordered, func() {
 			originalTemplatesPullTimestamp, err = getLastPullTime(cfg.Repositories.Templates.Value)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(corectl.Run(
-				"config", "update",
-			)).To(Succeed())
+			_, err = corectl.Run("config", "update")
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("pulls configuration changes from remote configuration repositories", func() {

--- a/tests/integration/env/connect.go
+++ b/tests/integration/env/connect.go
@@ -27,7 +27,7 @@ var _ = Describe("env", Ordered, func() {
 			It("returns meaningful error when no credentials provided", func() {
 				Expect(os.Setenv("CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", "/tmp/not-exist")).NotTo(HaveOccurred())
 
-				err := corectl.Run("env", "connect", testdata.DevEnvironment())
+				_, err := corectl.Run("env", "connect", testdata.DevEnvironment())
 
 				Expect(err.Error()).To(SatisfyAll(
 					ContainSubstring("Error: create google cluster client: credentials: could not find default credentials"),

--- a/tests/integration/p2p/export.go
+++ b/tests/integration/p2p/export.go
@@ -1,0 +1,107 @@
+package p2p
+
+import (
+	"github.com/coreeng/corectl/pkg/cmdutil/config"
+	"github.com/coreeng/corectl/testdata"
+	"github.com/coreeng/corectl/tests/integration/testconfig"
+	"github.com/coreeng/corectl/tests/integration/testsetup"
+	"github.com/coreeng/developer-platform/pkg/environment"
+	"github.com/go-git/go-git/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/thanhpk/randstr"
+	"path/filepath"
+)
+
+var _ = Describe("export", Ordered, func() {
+	t := GinkgoT()
+	var (
+		corectl *testconfig.CorectlClient
+		env     *environment.Environment
+		appDir  string
+	)
+
+	BeforeAll(func() {
+		var cfg *config.Config
+		homeDir := tmpDir(t)
+		corectl, cfg = initCorectl(homeDir)
+		appDir = onboardTestApp(homeDir, corectl)
+		env = defaultEnv(cfg.Repositories.CPlatform.Value)
+	})
+
+	Context("export", func() {
+
+		var commitHash = func(repoPath string) string {
+			r, err := git.PlainOpen(repoPath)
+			Expect(err).NotTo(HaveOccurred())
+			ref, err := r.Head()
+			Expect(err).NotTo(HaveOccurred())
+			return ref.Hash().String()[0:7]
+		}
+
+		var assertExportStatements = func(act string) {
+			Expect(act).To(SatisfyAll(
+				ContainSubstring("export REGION=\"%s\"", env.Platform.(*environment.GCPVendor).Region),
+				ContainSubstring("export REGISTRY=\"%s-docker.pkg.dev/%s/tenant/%s\"", env.Platform.(*environment.GCPVendor).Region, env.Platform.(*environment.GCPVendor).ProjectId, testconfig.Cfg.Tenant),
+				ContainSubstring("export BASE_DOMAIN=\"%s\"", env.GetDefaultIngressDomain().Domain),
+				ContainSubstring("export REPO_PATH=\"%s\"", appDir),
+				ContainSubstring("export TENANT_NAME=\"%s\"", testconfig.Cfg.Tenant),
+				ContainSubstring("export VERSION=\"%s\"", commitHash(appDir))))
+		}
+
+		Context("print out env variables", func() {
+			It("as export statements", func() {
+				output, err := corectl.Run("p2p", "export", "--tenant", testconfig.Cfg.Tenant, "--environment", testdata.DevEnvironment(), "--repoPath", appDir)
+
+				Expect(err).NotTo(HaveOccurred())
+				assertExportStatements(output)
+			})
+			It("with shorthand flags", func() {
+				output, err := corectl.Run("p2p", "export", "-t", testconfig.Cfg.Tenant, "-e", testdata.DevEnvironment(), "-r", appDir)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(output).ToNot(BeEmpty())
+			})
+
+			It("defaulting to local dir when no repoPath flag passed", func() {
+				output, err := corectl.RunInDir(appDir, "p2p", "export", "--tenant", testconfig.Cfg.Tenant, "--environment", testdata.DevEnvironment())
+
+				Expect(err).NotTo(HaveOccurred())
+				assertExportStatements(output)
+			})
+		})
+	})
+})
+
+func initCorectl(homeDir string) (*testconfig.CorectlClient, *config.Config) {
+	corectl := testconfig.NewCorectlClient(homeDir)
+	cfg, _, err := testsetup.InitCorectl(corectl)
+	Expect(err).ToNot(HaveOccurred())
+	return corectl, cfg
+}
+
+func onboardTestApp(homeDir string, corectl *testconfig.CorectlClient) string {
+	testsetup.SetupGitGlobalConfigFromCurrentToOtherHomeDir(homeDir)
+	newAppName := "new-test-app-" + randstr.Hex(6)
+	appDir := filepath.Join(homeDir, newAppName)
+	_, err := corectl.Run(
+		"application", "create", newAppName, appDir,
+		"-t", testdata.BlankTemplate(),
+		"--tenant", testconfig.Cfg.Tenant,
+		"--nonint")
+	Expect(err).ToNot(HaveOccurred())
+	return appDir
+}
+
+// macOS has a symlink from /var -> private/var causing a wrong app dir path, ensure we're using actual path
+func tmpDir(t GinkgoTInterface) string {
+	d, err := filepath.EvalSymlinks(t.TempDir())
+	Expect(err).ToNot(HaveOccurred())
+	return d
+}
+
+func defaultEnv(cPlatRepoPath string) *environment.Environment {
+	e, err := environment.FindByName(environment.DirFromCPlatformRepoPath(cPlatRepoPath), testdata.DevEnvironment())
+	Expect(err).ToNot(HaveOccurred())
+	return e
+}

--- a/tests/integration/p2p/p2p.go
+++ b/tests/integration/p2p/p2p.go
@@ -66,11 +66,11 @@ var _ = Describe("p2p", Ordered, func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(corectl.Run(
+			_, err := corectl.Run(
 				"p2p", "env", "sync",
 				appRepo,
-				tenant,
-			)).To(Succeed())
+				tenant)
+			Expect(err).ToNot(HaveOccurred())
 		}, NodeTimeout(time.Minute))
 
 		AfterAll(func(ctx SpecContext) {

--- a/tests/integration/tenant/tenant.go
+++ b/tests/integration/tenant/tenant.go
@@ -37,7 +37,7 @@ var _ = Describe("tenant", Ordered, func() {
 
 		BeforeAll(func() {
 			newTenantName = "new-tenant-name-" + randstr.Hex(6)
-			Expect(corectl.Run(
+			_, err := corectl.Run(
 				"tenant", "create",
 				"--name", newTenantName,
 				"--parent", "parent",
@@ -48,8 +48,8 @@ var _ = Describe("tenant", Ordered, func() {
 				// Omitting repositories parameter
 				"--admin-group", "ag",
 				"--readonly-group", "rg",
-				"--nonint",
-			)).To(Succeed())
+				"--nonint")
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("created a PR in the CPlatform repository", func(ctx SpecContext) {

--- a/tests/integration/testconfig/corectl_client.go
+++ b/tests/integration/testconfig/corectl_client.go
@@ -26,10 +26,10 @@ func NewCorectlClient(homeDir string) *CorectlClient {
 	}
 }
 
-func (c *CorectlClient) Run(args ...string) error {
+func (c *CorectlClient) RunInDir(dir string, args ...string) (string, error) {
 	cmd := exec.Command(c.binaryPath, args...)
 	cmd.Env = c.env
-	cmd.Dir = c.homeDir
+	cmd.Dir = dir
 
 	outBuf := bytes.Buffer{}
 	outWriter := bufio.NewWriter(&outBuf)
@@ -38,9 +38,13 @@ func (c *CorectlClient) Run(args ...string) error {
 
 	if err := cmd.Run(); err != nil {
 		println(outBuf.String())
-		return fmt.Errorf("%s: %w", outBuf.String(), err)
+		return "", fmt.Errorf("%s: %w", outBuf.String(), err)
 	}
-	return nil
+	return outBuf.String(), nil
+}
+
+func (c *CorectlClient) Run(args ...string) (string, error) {
+	return c.RunInDir(c.homeDir, args...)
 }
 
 func (c *CorectlClient) HomeDir() string {

--- a/tests/integration/testsetup/config_init.go
+++ b/tests/integration/testsetup/config_init.go
@@ -26,7 +26,7 @@ func InitCorectl(corectl *testconfig.CorectlClient) (*config.Config, *CorectlCon
 }
 
 func InitCorectlWithFile(corectl *testconfig.CorectlClient, initFilePath string) (*config.Config, *CorectlConfigDetails, error) {
-	err := corectl.Run(
+	_, err := corectl.Run(
 		"config", "init",
 		"--file", initFilePath,
 		"--github-token", testconfig.Cfg.GitHubToken,


### PR DESCRIPTION
new functionality that allows to export required env variables required to execute onboarded apps p2p make targets issue: https://github.com/coreeng/project-platform-accelerator/issues/396. The command will print out export statements in new lines as:
```
export BASE_DOMAIN="gcp-dev.cecg.platform.cecg.io"                                 
export REPO_PATH="../tombart-app"                                                  
export REGION="europe-west2"                                                       
export REGISTRY="europe-west2-docker.pkg.dev/core-platform-efb3c84c/tenant/tomaszb"
export VERSION="53b9c85"                                                           
export TENANT_NAME="tomaszb" 
```
The user is expected to copy and paste in terminal.

Example run:
`corectl p2p export --tenant tomaszb --environment gcp-dev --repoPath ../tombart-app`
or
`corectl p2p export --tenant tomaszb --environment gcp-dev` -- defaults to current dir
or
`eval $(corectl p2p export --tenant tomaszb --environment gcp-dev --repoPath ../tombart-app)` -- automatically add vars to current shell

There is quite a lot of duplication in the tool in both logic and code, however due to the size of this pr didn't do much cleanup. Probably better to tackle separately as sep tickets. Also p2p sync command is quite similar to this one, however not very extensible to be re-used. Would need to major refactoring which decided not to do as a part of this work.