### PR TITLE
Make app create `--from-template` flag optional

### DIFF
--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -326,9 +326,10 @@ func (opts *AppCreateOpt) createTenantInput(existingTenant []coretnt.Tenant) use
 }
 
 func (opts *AppCreateOpt) createTemplateInput(existingTemplates []template.Spec) userio.InputSourceSwitch[string, *template.Spec] {
-	availableTemplateNames := make([]string, len(existingTemplates))
+	availableTemplateNames := make([]string, len(existingTemplates)+1)
+	availableTemplateNames[0] = "<empty>"
 	for i, t := range existingTemplates {
-		availableTemplateNames[i] = t.Name
+		availableTemplateNames[i+1] = t.Name
 	}
 	return userio.InputSourceSwitch[string, *template.Spec]{
 		DefaultValue: userio.AsZeroable(opts.FromTemplate),
@@ -340,6 +341,9 @@ func (opts *AppCreateOpt) createTemplateInput(existingTemplates []template.Spec)
 		},
 		ValidateAndMap: func(inp string) (*template.Spec, error) {
 			inp = strings.TrimSpace(inp)
+			if inp == "<empty>" {
+				return nil, nil
+			}
 			templateIndex := slices.IndexFunc(existingTemplates, func(spec template.Spec) bool {
 				return spec.Name == inp
 			})

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -222,18 +222,22 @@ func createNewApp(
 	extendedTestEnvs := filterEnvsByNames(cfg.P2P.ExtendedTest.DefaultEnvs.Value, existingEnvs)
 	prodEnvs := filterEnvsByNames(cfg.P2P.Prod.DefaultEnvs.Value, existingEnvs)
 
-	fulfilledTemplate := template.FulfilledTemplate{
-		Spec: fromTemplate,
-		Arguments: []template.Argument{
-			{
-				Name:  "name",
-				Value: opts.Name,
+	var fulfilledTemplate *template.FulfilledTemplate
+
+	if fromTemplate != nil {
+		fulfilledTemplate = &template.FulfilledTemplate{
+			Spec: fromTemplate,
+			Arguments: []template.Argument{
+				{
+					Name:  "name",
+					Value: opts.Name,
+				},
+				{
+					Name:  "tenant",
+					Value: opts.Tenant,
+				},
 			},
-			{
-				Name:  "tenant",
-				Value: opts.Tenant,
-			},
-		},
+		}
 	}
 
 	gitAuth := git.UrlTokenAuthMethod(cfg.GitHub.Token.Value)
@@ -245,7 +249,7 @@ func createNewApp(
 		FastFeedbackEnvs: fastFeedbackEnvs,
 		ExtendedTestEnvs: extendedTestEnvs,
 		ProdEnvs:         prodEnvs,
-		Template:         &fulfilledTemplate,
+		Template:         fulfilledTemplate,
 		GitAuth:          gitAuth,
 	}
 	if err := application.ValidateCreate(appCreateOp, githubClient); err != nil {
@@ -333,6 +337,7 @@ func (opts *AppCreateOpt) createTemplateInput(existingTemplates []template.Spec)
 	}
 	return userio.InputSourceSwitch[string, *template.Spec]{
 		DefaultValue: userio.AsZeroable(opts.FromTemplate),
+		Optional:     true,
 		InteractivePromptFn: func() (userio.InputPrompt[string], error) {
 			return &userio.SingleSelect{
 				Prompt: "Template:",
@@ -341,7 +346,7 @@ func (opts *AppCreateOpt) createTemplateInput(existingTemplates []template.Spec)
 		},
 		ValidateAndMap: func(inp string) (*template.Spec, error) {
 			inp = strings.TrimSpace(inp)
-			if inp == "<empty>" {
+			if inp == "<empty>" || inp == "" {
 				return nil, nil
 			}
 			templateIndex := slices.IndexFunc(existingTemplates, func(spec template.Spec) bool {

--- a/pkg/cmd/application/create/app_create_test.go
+++ b/pkg/cmd/application/create/app_create_test.go
@@ -32,6 +32,7 @@ var _ = Describe("AppCreateOpt", func() {
 
 			// Check the interactive prompt
 			prompt, err := input.InteractivePromptFn()
+
 			Expect(err).NotTo(HaveOccurred())
 			singleSelect, ok := prompt.(*userio.SingleSelect)
 			Expect(ok).To(BeTrue())
@@ -68,6 +69,17 @@ var _ = Describe("AppCreateOpt", func() {
 			result, err := input.ValidateAndMap("<empty>")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(BeNil())
+		})
+
+		It("should handle interactive mode", func() {
+			existingTemplates := []template.Spec{}
+
+			input := opts.createTemplateInput(existingTemplates)
+
+			value, err := input.GetValue(userio.NewIOStreamsWithInteractive(nil, nil, false))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(value).To(BeNil())
 		})
 	})
 })

--- a/pkg/cmd/application/create/app_create_test.go
+++ b/pkg/cmd/application/create/app_create_test.go
@@ -1,0 +1,73 @@
+package create
+
+import (
+	"github.com/coreeng/corectl/pkg/cmdutil/userio"
+	"github.com/coreeng/corectl/pkg/template"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestAppCreateSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "App Create Suite")
+}
+
+var _ = Describe("AppCreateOpt", func() {
+	Describe("createTemplateInput", func() {
+		var opts *AppCreateOpt
+
+		BeforeEach(func() {
+			opts = &AppCreateOpt{}
+		})
+
+		It("should create a template input with an 'empty' option and existing templates", func() {
+			existingTemplates := []template.Spec{
+				{Name: "template1"},
+				{Name: "template2"},
+				{Name: "template3"},
+			}
+
+			input := opts.createTemplateInput(existingTemplates)
+
+			// Check the interactive prompt
+			prompt, err := input.InteractivePromptFn()
+			Expect(err).NotTo(HaveOccurred())
+			singleSelect, ok := prompt.(*userio.SingleSelect)
+			Expect(ok).To(BeTrue())
+			Expect(singleSelect.Items).To(Equal([]string{"<empty>", "template1", "template2", "template3"}))
+
+			// Test empty selection
+			result, err := input.ValidateAndMap("<empty>")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+
+			// Test valid template selection
+			result, err = input.ValidateAndMap("template2")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(&existingTemplates[1]))
+
+			// Test invalid template selection
+			result, err = input.ValidateAndMap("nonexistent")
+			Expect(err).To(MatchError("unknown template"))
+			Expect(result).To(BeNil())
+
+		})
+
+		It("should handle an empty list of existing templates", func() {
+			existingTemplates := []template.Spec{}
+
+			input := opts.createTemplateInput(existingTemplates)
+
+			prompt, err := input.InteractivePromptFn()
+			Expect(err).NotTo(HaveOccurred())
+			singleSelect, ok := prompt.(*userio.SingleSelect)
+			Expect(ok).To(BeTrue())
+			Expect(singleSelect.Items).To(Equal([]string{"<empty>"}))
+
+			result, err := input.ValidateAndMap("<empty>")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
In a monorepo setup we need to create an empty root repository that will have all of the p2p variables set but without any workflows defined. We could have a specific `monorepo` software template or alternatively don't use any of the templates. This PR makes `--from-template` parameter optional to enable this. 



## Usage
- interactive mode

![CleanShot 2024-08-22 at 12 15 32@2x](https://github.com/user-attachments/assets/95217d75-82a9-4d75-a589-e8f8b8d5d233)

- non interactive mode
```shell
corectl app create lukasz-app-1 --tenant lukasz-app-1 --nonint
```
