### PR TITLE
Set working_directory and version_prefix arguments for monorepo flow

### DIFF
--- a/pkg/cmd/template/render/parameters_test.go
+++ b/pkg/cmd/template/render/parameters_test.go
@@ -89,8 +89,10 @@ var _ = Describe("template arguments are collected", func() {
 	Context("from all sources", func() {
 		It("with non-interactive input => skips optional args", func(ctx SpecContext) {
 			argsFile := createArgsFile(t.TempDir(), map[string]string{
-				"name":   "app-name",
-				"tenant": "tenant-name",
+				"name":              "app-name",
+				"tenant":            "tenant-name",
+				"working_directory": "/path/to/app",
+				"version_prefix":    "v",
 			})
 			stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
 			streams := userio.NewTestIOStreams(
@@ -121,6 +123,14 @@ var _ = Describe("template arguments are collected", func() {
 					Name:  "tenant",
 					Value: "tenant-name",
 				},
+				{
+					Name:  "working_directory",
+					Value: "/path/to/app",
+				},
+				{
+					Name:  "version_prefix",
+					Value: "v",
+				},
 				// From flags
 				{
 					Name:  "param1",
@@ -142,9 +152,11 @@ var _ = Describe("template arguments are collected", func() {
 
 		It("with interactive input", func(ctx SpecContext) {
 			argsFile := createArgsFile(t.TempDir(), map[string]string{
-				"name":   "app-name",
-				"tenant": "tenant-name",
-				"param4": "3456",
+				"name":              "app-name",
+				"tenant":            "tenant-name",
+				"working_directory": "/path/to/app",
+				"version_prefix":    "v",
+				"param4":            "3456",
 			})
 			stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
 			streams := userio.NewTestIOStreams(
@@ -182,6 +194,14 @@ var _ = Describe("template arguments are collected", func() {
 				{
 					Name:  "param4",
 					Value: 3456,
+				},
+				{
+					Name:  "working_directory",
+					Value: "/path/to/app",
+				},
+				{
+					Name:  "version_prefix",
+					Value: "v",
 				},
 				// From flags
 				{

--- a/pkg/cmd/template/render/template_render.go
+++ b/pkg/cmd/template/render/template_render.go
@@ -89,10 +89,6 @@ func run(opts TemplateRenderOpts) error {
 		return fmt.Errorf("%s: unknown template", opts.TemplateName)
 	}
 
-	if err != nil {
-		return err
-	}
-
 	templateRenderer := &FlagsAwareTemplateRenderer{
 		ArgsFile: opts.ArgsFile,
 		Args:     opts.Args,

--- a/pkg/cmd/template/render/template_render.go
+++ b/pkg/cmd/template/render/template_render.go
@@ -89,24 +89,53 @@ func run(opts TemplateRenderOpts) error {
 		return fmt.Errorf("%s: unknown template", opts.TemplateName)
 	}
 
+	if err != nil {
+		return err
+	}
+
+	templateRenderer := &FlagsAwareTemplateRenderer{
+		ArgsFile: opts.ArgsFile,
+		Args:     opts.Args,
+		Streams:  opts.Streams,
+	}
+
+	if err := templateRenderer.Render(templ, opts.TargetPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type TemplateRenderer interface {
+	Render(spec *template.Spec, targetDirectory string, additionalArgs ...template.Argument) error
+}
+
+type FlagsAwareTemplateRenderer struct {
+	ArgsFile string
+	Args     []string
+	Streams  userio.IOStreams
+}
+
+func (r *FlagsAwareTemplateRenderer) Render(spec *template.Spec, targetDirectory string, additionalArgs ...template.Argument) error {
+	if spec == nil {
+		return nil
+	}
+
 	args, err := CollectArgsFromAllSources(
-		templ,
-		opts.ArgsFile,
-		opts.Args,
-		opts.Streams,
-		[]template.Argument{},
+		spec,
+		r.ArgsFile,
+		r.Args,
+		r.Streams,
+		additionalArgs,
 	)
 	if err != nil {
 		return err
 	}
 
-	fulfilledT := template.FulfilledTemplate{
-		Spec:      templ,
+	fulfilledTemplate := &template.FulfilledTemplate{
+		Spec:      spec,
 		Arguments: args,
 	}
-	if err := template.Render(&fulfilledT, opts.TargetPath); err != nil {
-		return err
-	}
 
-	return nil
+	return template.Render(fulfilledTemplate, targetDirectory)
 }

--- a/pkg/cmd/template/render/template_render_test.go
+++ b/pkg/cmd/template/render/template_render_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Template Render", Ordered, func() {
 		Expect(string(renderedContent)).To(ContainSubstring(expectedTenantName))
 	})
 
-	It("should render the template correctly when params file is not provided", func() {
+	It("should throw an error when missing required implicit arguments", func() {
 		opts := TemplateRenderOpts{
 			IgnoreChecks:  false,
 			TemplateName:  testdata.BlankTemplate(),
@@ -73,12 +73,8 @@ var _ = Describe("Template Render", Ordered, func() {
 		}
 
 		err := run(opts)
-		Expect(err).NotTo(HaveOccurred())
-
-		renderedContent, err := os.ReadFile(filepath.Join(targetDir, ".github", "workflows", "extended-test.yaml"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(renderedContent)).NotTo(ContainSubstring(expectedName))
-		Expect(string(renderedContent)).NotTo(ContainSubstring(expectedTenantName))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("required argument name is missing"))
 	})
 
 	It("should render the template correctly when params passed with args", func() {

--- a/pkg/template/parameter.go
+++ b/pkg/template/parameter.go
@@ -12,13 +12,27 @@ var ImplicitParameters = []Parameter{
 		Name:        "name",
 		Description: "application name",
 		Type:        StringParamType,
-		Optional:    true,
+		Optional:    false,
 	},
 	{
 		Name:        "tenant",
 		Description: "tenant used to deploy the application",
 		Type:        StringParamType,
-		Optional:    true,
+		Optional:    false,
+	},
+	{
+		Name:        "working_directory",
+		Description: "working directory where application is located",
+		Type:        StringParamType,
+		Optional:    false,
+		Default:     "./",
+	},
+	{
+		Name:        "version_prefix",
+		Description: "version prefix for application",
+		Type:        StringParamType,
+		Optional:    false,
+		Default:     "v",
 	},
 }
 

--- a/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/extended-test.yaml
@@ -1,3 +1,5 @@
-# sample extended test workflow
-{{ name | default("") }}
-{{ tenant | default("") }}
+# sample fast feedback workflow
+name: {{ name | default("") }}
+tenant: {{ tenant | default("") }}
+working_directory: {{ working_directory | default("") }}
+version_prefix: {{ version_prefix | default("") }}

--- a/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
+++ b/testdata/software-templates/blank/skeleton/.github/workflows/fast-feedback.yaml
@@ -1,3 +1,5 @@
 # sample fast feedback workflow
-{{ name | default("") }}
-{{ tenant | default("") }}
+name: {{ name | default("") }}
+tenant: {{ tenant | default("") }}
+working_directory: {{ working_directory | default("") }}
+version_prefix: {{ version_prefix | default("") }}

--- a/testdata/software-templates/blank/template.yaml
+++ b/testdata/software-templates/blank/template.yaml
@@ -1,14 +1,3 @@
 name: blank
 description: Blank template with P2P related skeleton files
 skeletonPath: ./skeleton
-parameters:
-  - name: working_directory
-    description: working directory
-    type: string
-    optional: true
-    default: './'
-  - name: version_prefix
-    description: version prefix
-    type: string
-    optional: true
-    default: 'v'

--- a/testdata/software-templates/blank/template.yaml
+++ b/testdata/software-templates/blank/template.yaml
@@ -1,3 +1,14 @@
 name: blank
 description: Blank template with P2P related skeleton files
 skeletonPath: ./skeleton
+parameters:
+  - name: working_directory
+    description: working directory
+    type: string
+    optional: true
+    default: './'
+  - name: version_prefix
+    description: version prefix
+    type: string
+    optional: true
+    default: 'v'


### PR DESCRIPTION
When rendering application inside of monorepo github workflows require knowing in which directory application resides and what should be the prefix for version. 

Setting parameter defintion to 
```
parameters:
  - name: working_directory
    description: working directory
    type: string
    optional: true
    default: './'
  - name: `
    description: version prefix
    type: string
    optional: true
    default: 'v'
```
and then override `working_directory` and `version_prefix` in monorepo flow does the trick. 


I've refactored code a bit to only pass data in `CreateOp` and everything else is set as dependency on struct

Introduce `TemplateRenderer` interface to be able to test error scenario in tests