### PR TITLE
feat(cmd): add release version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,7 +3,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
@@ -14,6 +14,10 @@ builds:
     binary: corectl
     ldflags:
       - '-s -w'
+      - -X {{.ModulePath}}/pkg/cmd/version.version={{.Version}}
+      - -X {{.ModulePath}}/pkg/cmd/version.commit={{.Commit}}
+      - -X {{.ModulePath}}/pkg/cmd/version.date={{.Date}}
+      - -X {{.ModulePath}}/pkg/cmd/version.arch={{.Arch}}
     targets:
       - linux_amd64
       - linux_arm64

--- a/cmd/corectl/main.go
+++ b/cmd/corectl/main.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/coreeng/corectl/pkg/cmd"
 	"os"
+
+	"github.com/coreeng/corectl/pkg/cmd"
 )
 
 func main() {

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/coreeng/corectl/pkg/cmd/p2p"
 	"github.com/coreeng/corectl/pkg/cmd/template"
 	"github.com/coreeng/corectl/pkg/cmd/tenant"
+	"github.com/coreeng/corectl/pkg/cmd/version"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/spf13/cobra"
 )
@@ -41,6 +42,7 @@ func NewRootCmd(cfg *config.Config) *cobra.Command {
 	rootCmd.AddCommand(tenant.NewTenantCmd(cfg))
 	rootCmd.AddCommand(template.NewTemplateCmd(cfg))
 	rootCmd.AddCommand(env.NewEnvCmd(cfg))
+	rootCmd.AddCommand(version.VersionCmd(cfg))
 
 	return rootCmd
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/coreeng/corectl/pkg/cmd/root"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
-	"os"
 )
 
 func Run() int {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import (
+	"fmt"
+
+	"github.com/coreeng/corectl/pkg/cmdutil/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "unknown"
+	date    = "unknown"
+	arch    = "unknown"
+)
+
+func VersionCmd(cfg *config.Config) *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "List corectl version",
+		Long:  `This command allows you to list the currently running corectl version.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Printf("corectl %s (commit: %s) %s %s\n", version, commit, date, arch)
+		},
+	}
+
+	return versionCmd
+}

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -19,7 +19,8 @@ func VersionCmd(cfg *config.Config) *cobra.Command {
 		Use:   "version",
 		Short: "List corectl version",
 		Long:  `This command allows you to list the currently running corectl version.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _args []string) {
 			fmt.Printf("corectl %s (commit: %s) %s %s\n", version, commit, date, arch)
 		},
 	}

--- a/tests/integration/suite_test.go
+++ b/tests/integration/suite_test.go
@@ -23,6 +23,7 @@ import (
 	_ "github.com/coreeng/corectl/tests/integration/env"
 	_ "github.com/coreeng/corectl/tests/integration/p2p"
 	_ "github.com/coreeng/corectl/tests/integration/tenant"
+	_ "github.com/coreeng/corectl/tests/integration/version"
 )
 
 func TestSuite(t *testing.T) {

--- a/tests/integration/version/version.go
+++ b/tests/integration/version/version.go
@@ -1,0 +1,28 @@
+package version
+
+import (
+	"github.com/coreeng/corectl/testdata"
+	"github.com/coreeng/corectl/tests/integration/testconfig"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("version", Ordered, func() {
+	t := GinkgoT()
+	var (
+		corectl *testconfig.CorectlClient
+	)
+
+	BeforeAll(func() {
+		homeDir := t.TempDir()
+		corectl = testconfig.NewCorectlClient(homeDir)
+	})
+
+	Context("version", func() {
+		It("returns sensible defaults", func() {
+			output, err := corectl.Run("version", testdata.DevEnvironment())
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(output).Should(MatchRegexp("corectl (?P<tag>[a-z0-9\\.]+?) \\(commit: (?P<commit>[0-9a-f]+?)\\) (?P<date>.+?) (?P<arch>.+)"))
+		})
+	})
+})

--- a/tests/integration/version/version.go
+++ b/tests/integration/version/version.go
@@ -1,7 +1,6 @@
 package version
 
 import (
-	"github.com/coreeng/corectl/testdata"
 	"github.com/coreeng/corectl/tests/integration/testconfig"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -20,7 +19,7 @@ var _ = Describe("version", Ordered, func() {
 
 	Context("version", func() {
 		It("returns sensible defaults", func() {
-			output, err := corectl.Run("version", testdata.DevEnvironment())
+			output, err := corectl.Run("version")
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(output).Should(MatchRegexp("corectl (?P<tag>[a-z0-9\\.]+?) \\(commit: (?P<commit>[0-9a-f]+?)\\) (?P<date>.+?) (?P<arch>.+)"))
 		})


### PR DESCRIPTION
Updates the ldflags in the goreleaser config so that we can plug the values straight into the versionCmd.

![image](https://github.com/user-attachments/assets/23bfc88d-3917-4669-9036-17bb128755d5)
