### PR TITLE
feature(monorepo): trigger workflow in monorepo only for changed apps

### DIFF
--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -150,7 +150,7 @@ func (svc *Service) handleMonorepo(op CreateOp, localRepo *git.LocalRepository) 
 	additionalArgs := []template.Argument{
 		{
 			Name:  "working_directory",
-			Value: "./" + appRelPath,
+			Value: appRelPath,
 		},
 		{
 			Name:  "version_prefix",

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -429,7 +429,7 @@ var _ = Describe("Create new application", func() {
 				},
 				template.Argument{
 					Name:  "working_directory",
-					Value: "./" + appName,
+					Value: appName,
 				},
 				template.Argument{
 					Name:  "version_prefix",
@@ -444,13 +444,13 @@ var _ = Describe("Create new application", func() {
 			content := readFileContent(rootWorkflowsPath, "new-app-name-fast-feedback.yaml")
 			Expect(content).To(ContainSubstring("tenant: " + defaultTenant.Name))
 			Expect(content).To(ContainSubstring("name: " + appName))
-			Expect(content).To(ContainSubstring("working_directory: " + "./" + appName))
+			Expect(content).To(ContainSubstring("working_directory: " + appName))
 			Expect(content).To(ContainSubstring("version_prefix: " + appName + "/v"))
 
 			content = readFileContent(rootWorkflowsPath, "new-app-name-extended-test.yaml")
 			Expect(content).To(ContainSubstring("tenant: " + defaultTenant.Name))
 			Expect(content).To(ContainSubstring("name: " + appName))
-			Expect(content).To(ContainSubstring("working_directory: " + "./" + appName))
+			Expect(content).To(ContainSubstring("working_directory: " + appName))
 			Expect(content).To(ContainSubstring("version_prefix: " + appName + "/v"))
 		})
 

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -112,6 +112,10 @@ NOTE:
 		"Dry run",
 	)
 
+	config.RegisterBoolParameterAsFlag(
+		&cfg.Repositories.AllowDirty,
+		appCreateCmd.Flags(),
+	)
 	config.RegisterStringParameterAsFlag(
 		&cfg.GitHub.Token,
 		appCreateCmd.Flags(),
@@ -141,13 +145,13 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 	defer wizard.Done()
 
 	opts.Streams.CurrentHandler.Info(fmt.Sprintf("resetting local repository [repo=%s]", cfg.Repositories.CPlatform.Value))
-	if !opts.DryRun {
+	if !opts.DryRun && !cfg.Repositories.AllowDirty.Value {
 		if _, err := config.ResetConfigRepositoryState(&cfg.Repositories.CPlatform, opts.DryRun); err != nil {
 			return fmt.Errorf("failed to reset config repository state for CPlatform: %w", err)
 		}
 	}
 	opts.Streams.CurrentHandler.Info(fmt.Sprintf("resetting local repository [repo=%s]", cfg.Repositories.Templates.Value))
-	if !opts.DryRun {
+	if !opts.DryRun && !cfg.Repositories.AllowDirty.Value {
 		if _, err := config.ResetConfigRepositoryState(&cfg.Repositories.Templates, opts.DryRun); err != nil {
 			return fmt.Errorf("failed to reset config repository state for Templates: %w", err)
 		}

--- a/pkg/cmd/template/render/template_render.go
+++ b/pkg/cmd/template/render/template_render.go
@@ -35,7 +35,7 @@ func NewTemplateRenderCmd(cfg *config.Config) *cobra.Command {
 			opts.TargetPath = args[1]
 			opts.TemplatesPath = cfg.Repositories.Templates.Value
 
-			if !opts.IgnoreChecks {
+			if !cfg.Repositories.AllowDirty.Value {
 				if _, err := config.ResetConfigRepositoryState(&cfg.Repositories.Templates, false); err != nil {
 					return err
 				}
@@ -44,13 +44,6 @@ func NewTemplateRenderCmd(cfg *config.Config) *cobra.Command {
 			return run(opts)
 		},
 	}
-
-	templateRenderCmd.Flags().BoolVar(
-		&opts.IgnoreChecks,
-		"ignore-checks",
-		false,
-		"Ignore checks for uncommitted changes and branch status",
-	)
 
 	templateRenderCmd.Flags().StringVar(
 		&opts.ArgsFile,
@@ -66,6 +59,10 @@ func NewTemplateRenderCmd(cfg *config.Config) *cobra.Command {
 		"Template argument in the format: <arg-name>=<arg-value>",
 	)
 
+	config.RegisterBoolParameterAsFlag(
+		&cfg.Repositories.AllowDirty,
+		templateRenderCmd.Flags(),
+	)
 	config.RegisterStringParameterAsFlag(
 		&cfg.Repositories.Templates,
 		templateRenderCmd.Flags(),

--- a/pkg/cmdutil/config/config.go
+++ b/pkg/cmdutil/config/config.go
@@ -67,7 +67,7 @@ func RegisterStringParameterAsFlag(p *Parameter[string], fs *pflag.FlagSet) {
 			p.help,
 		)
 	}
-	hideDefaultValueFromHelp(p, fs)
+	hideDefaultValueFromHelp(p, fs, "")
 }
 
 func RegisterBoolParameterAsFlag(p *Parameter[bool], fs *pflag.FlagSet) {
@@ -90,13 +90,13 @@ func RegisterBoolParameterAsFlag(p *Parameter[bool], fs *pflag.FlagSet) {
 			p.help,
 		)
 	}
-	hideDefaultValueFromHelp(p, fs)
+	hideDefaultValueFromHelp(p, fs, "false")
 }
 
-func hideDefaultValueFromHelp[V any](p *Parameter[V], fs *pflag.FlagSet) {
+func hideDefaultValueFromHelp[V any](p *Parameter[V], fs *pflag.FlagSet, zeroValue string) {
 	// do not output value from config in help
 	flag := fs.Lookup(p.flag)
-	flag.DefValue = ""
+	flag.DefValue = zeroValue
 }
 
 type Config struct {


### PR DESCRIPTION
- exclude "./" from working_directory template parameter, so it can be used in "paths" trigger parameter in GH workflow files. For some reason, it doesn't work with "./" prefix
- Add an option to specify `--allow-dirty` flag to more commands