### PR TITLE
feature(wizard): Display skipped task message in case repository is already present in tenant definition

### DIFF
--- a/pkg/cmdutil/userio/file_picker.go
+++ b/pkg/cmdutil/userio/file_picker.go
@@ -55,7 +55,7 @@ func (ifp *FilePicker) GetInput(streams IOStreams) (string, error) {
 		styles:         streams.styles,
 	}
 
-	result, err := streams.execute(ifpModel, nil)
+	result, err := streams.execute(ifpModel)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmdutil/userio/interop.go
+++ b/pkg/cmdutil/userio/interop.go
@@ -2,12 +2,13 @@ package userio
 
 import (
 	"fmt"
-
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio/wizard"
 )
 
 type nonInteractiveHandler struct {
 	streams *IOStreams
+	styles  nonInteractiveStyles
 }
 
 func InfoLog(message string) string {
@@ -30,11 +31,14 @@ func (nih nonInteractiveHandler) Info(message string) {
 func (nih nonInteractiveHandler) Warn(message string) {
 	_, _ = nih.streams.outRaw.Write([]byte(WarnLog(message) + "\n"))
 }
-func (nih nonInteractiveHandler) SetTask(title string, completedTitle string) {
-	nih.Info(fmt.Sprintf("[%s]", newNonInteractiveStyles().bold.Render(title)))
+func (nih nonInteractiveHandler) SetTask(title string, _ string) {
+	nih.Info(fmt.Sprintf("[%s]", nih.styles.bold.Render(title)))
 }
 func (nih nonInteractiveHandler) SetCurrentTaskCompletedTitle(completedTitle string) {
-	nih.Info(fmt.Sprintf("[%s]", newNonInteractiveStyles().bold.Render(completedTitle)))
+	nih.Info(fmt.Sprintf("[%s %s]", nih.styles.status.Render(wizard.TaskStatusSuccess), nih.styles.bold.Render(completedTitle)))
+}
+func (nih nonInteractiveHandler) SetCurrentTaskCompletedTitleWithStatus(completedTitle string, status wizard.TaskStatus) {
+	nih.Info(fmt.Sprintf("[%s %s]", nih.styles.status.Render(status), nih.styles.bold.Render(completedTitle)))
 }
 func (nih nonInteractiveHandler) SetInputModel(message tea.Model) tea.Model {
 	panic("cannot take input in non-interactive mode")

--- a/pkg/cmdutil/userio/multi_select.go
+++ b/pkg/cmdutil/userio/multi_select.go
@@ -42,7 +42,7 @@ func (op *MultiSelect) GetInput(streams IOStreams) ([]string, error) {
 		validateAndMap: op.ValidateAndMap,
 	}
 
-	result, err := streams.execute(model, nil)
+	result, err := streams.execute(model)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmdutil/userio/output.go
+++ b/pkg/cmdutil/userio/output.go
@@ -7,34 +7,37 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/userio/wizard"
 )
 
-func (streams IOStreams) InfoE(messages ...string) error {
+func (s IOStreams) InfoE(messages ...string) error {
 	msg := strings.Join(messages, "")
-	styledMsg := streams.styles.info.Render(msg)
-	_, err := streams.out.Output().Write([]byte(styledMsg))
+	styledMsg := s.styles.info.Render(msg)
+	_, err := s.out.Output().Write([]byte(styledMsg))
 	if err != nil {
 		return fmt.Errorf("couldn't output info message: %v", err)
 	}
 	if len(messages) > 0 && !strings.HasSuffix(msg, "\n") {
-		if _, err = streams.out.Output().Write([]byte("\n")); err != nil {
+		if _, err = s.out.Output().Write([]byte("\n")); err != nil {
 			return fmt.Errorf("couldn't output info message: %v", err)
 		}
 	}
 	return nil
 }
 
-func (streams IOStreams) Info(messages ...string) {
-	err := streams.InfoE(messages...)
+func (s IOStreams) Info(messages ...string) {
+	err := s.InfoE(messages...)
 	if err != nil {
 		panic(err.Error())
 	}
 }
 
-func (streams *IOStreams) Wizard(title string, completedTitle string) wizard.Handler {
-	if streams.IsInteractive() {
-		streams.CurrentHandler = newWizard(streams)
+func (s *IOStreams) Wizard(title string, completedTitle string) wizard.Handler {
+	if s.IsInteractive() {
+		s.CurrentHandler = newWizard(s)
 	} else {
-		streams.CurrentHandler = nonInteractiveHandler{streams: streams}
+		s.CurrentHandler = nonInteractiveHandler{
+			streams: s,
+			styles:  newNonInteractiveStyles(),
+		}
 	}
-	streams.CurrentHandler.SetTask(title, completedTitle)
-	return streams.CurrentHandler
+	s.CurrentHandler.SetTask(title, completedTitle)
+	return s.CurrentHandler
 }

--- a/pkg/cmdutil/userio/single_select.go
+++ b/pkg/cmdutil/userio/single_select.go
@@ -48,7 +48,7 @@ func (op *SingleSelect) GetInput(streams IOStreams) (string, error) {
 		model:  m,
 	}
 
-	result, err := streams.execute(model, nil)
+	result, err := streams.execute(model)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/cmdutil/userio/styles.go
+++ b/pkg/cmdutil/userio/styles.go
@@ -2,6 +2,7 @@ package userio
 
 import (
 	"github.com/charmbracelet/lipgloss"
+	"github.com/coreeng/corectl/pkg/cmdutil/userio/wizard"
 )
 
 var (
@@ -45,12 +46,15 @@ type nonInteractiveStyles struct {
 	warnHeadingStyle lipgloss.Style
 	warnMessageStyle lipgloss.Style
 	bold             lipgloss.Style
+	status           wizard.TaskStatusStyle
 }
 
-func newNonInteractiveStyles() *nonInteractiveStyles {
-	return &nonInteractiveStyles{
+func newNonInteractiveStyles() nonInteractiveStyles {
+	return nonInteractiveStyles{
 		infoStyle:        lipgloss.NewStyle().Foreground(lipgloss.Color("123")),
 		warnHeadingStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("227")),
 		warnMessageStyle: lipgloss.NewStyle().Foreground(lipgloss.Color("228")),
+		bold:             lipgloss.NewStyle().Bold(true),
+		status:           wizard.DefaultMarks(),
 	}
 }

--- a/pkg/cmdutil/userio/text_input.go
+++ b/pkg/cmdutil/userio/text_input.go
@@ -49,7 +49,7 @@ func (ti *TextInput[V]) GetInput(streams IOStreams) (V, error) {
 		styles:         streams.styles,
 	}
 
-	result, err := streams.execute(tiModel, nil)
+	result, err := streams.execute(tiModel)
 	if err != nil {
 		var noop V
 		return noop, err

--- a/pkg/cmdutil/userio/wizard/style.go
+++ b/pkg/cmdutil/userio/wizard/style.go
@@ -9,7 +9,28 @@ type Styles struct {
 	WarnLogHeading lipgloss.Style
 	InfoLogBody    lipgloss.Style
 	WarnLogBody    lipgloss.Style
-	CheckMark      lipgloss.Style
+	Marks          TaskStatusStyle
+}
+
+type TaskStatusStyle struct {
+	Success lipgloss.Style
+	Error   lipgloss.Style
+	Skipped lipgloss.Style
+}
+
+func (s TaskStatusStyle) Render(status TaskStatus) string {
+	switch status {
+	case taskStatusUnknown:
+		panic("unknown task status should not be rendered")
+	case TaskStatusSuccess:
+		return s.Success.Render()
+	case TaskStatusError:
+		return s.Error.Render()
+	case TaskStatusSkipped:
+		return s.Skipped.Render()
+	default:
+		panic("unknown task status")
+	}
 }
 
 func DefaultStyles() Styles {
@@ -20,6 +41,14 @@ func DefaultStyles() Styles {
 		InfoLogBody:    lipgloss.NewStyle().Foreground(lipgloss.Color("159")),
 		WarnLogHeading: lipgloss.NewStyle().Foreground(lipgloss.Color("227")),
 		WarnLogBody:    lipgloss.NewStyle().Foreground(lipgloss.Color("228")),
-		CheckMark:      lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓"),
+		Marks:          DefaultMarks(),
+	}
+}
+
+func DefaultMarks() TaskStatusStyle {
+	return TaskStatusStyle{
+		Success: lipgloss.NewStyle().Foreground(lipgloss.Color("42")).SetString("✓"),
+		Error:   lipgloss.NewStyle().Foreground(lipgloss.Color("9")).SetString("✗"),
+		Skipped: lipgloss.NewStyle().Foreground(lipgloss.Color("228")).SetString("⚠"),
 	}
 }

--- a/pkg/git/local_repository.go
+++ b/pkg/git/local_repository.go
@@ -160,6 +160,9 @@ func OpenAndResetRepositoryState(path string, dryRun bool) (*LocalRepository, er
 	if err != nil {
 		return nil, err
 	}
+	if dryRun {
+		return localRepo, nil
+	}
 	err = localRepo.ResetState()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Introduce different task completion statuses
- Introduce `anonymous` tasks, so we can output logs without the need to create a named task. Otherwise, it can push log messages to already completed a task which doesn't make sense + will rearrange output