### PR TITLE
fix(release): use Tag instead of Version as version label

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
     binary: corectl
     ldflags:
       - '-s -w'
-      - -X {{.ModulePath}}/pkg/version.Version={{.Version}}
+      - -X {{.ModulePath}}/pkg/version.Version={{.Tag}}
       - -X {{.ModulePath}}/pkg/version.Commit={{.Commit}}
       - -X {{.ModulePath}}/pkg/version.Date={{.Date}}
       - -X {{.ModulePath}}/pkg/version.Arch={{.Arch}}

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -70,6 +70,7 @@ NOTE:
 			opts.Streams = userio.NewIOStreamsWithInteractive(
 				os.Stdin,
 				os.Stdout,
+				os.Stderr,
 				!nonInteractive,
 			)
 			return run(&opts, cfg)

--- a/pkg/cmd/application/create/app_create_test.go
+++ b/pkg/cmd/application/create/app_create_test.go
@@ -89,7 +89,7 @@ var _ = Describe("AppCreateOpt", func() {
 			})
 
 			It("should handle interactive mode", func() {
-				value, err := input.GetValue(userio.NewIOStreamsWithInteractive(nil, nil, false))
+				value, err := input.GetValue(userio.NewIOStreamsWithInteractive(nil, nil, nil, false))
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(value).To(BeNil())

--- a/pkg/cmd/config/init/config_init.go
+++ b/pkg/cmd/config/init/config_init.go
@@ -51,6 +51,7 @@ func NewConfigInitCmd(cfg *config.Config) *cobra.Command {
 			opt.Streams = userio.NewIOStreamsWithInteractive(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 				!opt.NonInteractive,
 			)
 			return run(&opt, cfg)

--- a/pkg/cmd/config/set/config_set.go
+++ b/pkg/cmd/config/set/config_set.go
@@ -2,6 +2,7 @@ package set
 
 import (
 	"fmt"
+
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/spf13/cobra"
@@ -26,6 +27,7 @@ func NewConfigSetCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/config/update/config_update.go
+++ b/pkg/cmd/config/update/config_update.go
@@ -23,6 +23,7 @@ func NewConfigUpdateCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/config/view/config_view.go
+++ b/pkg/cmd/config/view/config_view.go
@@ -2,6 +2,7 @@ package view
 
 import (
 	"fmt"
+
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ func NewConfigViewCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/config/view/view_test.go
+++ b/pkg/cmd/config/view/view_test.go
@@ -13,13 +13,13 @@ import (
 
 var _ = Describe("config view", func() {
 	It("no options", func() {
-		stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
+		var stdin, stdout, stderr bytes.Buffer
 		originalCfg := config.NewTestPersistedConfig()
 		fillCfgWithMockValues(originalCfg)
 
 		cfg := *originalCfg
 		err := run(&ConfigViewOpts{
-			Streams: userio.NewIOStreams(&stdin, &stdout),
+			Streams: userio.NewIOStreams(&stdin, &stdout, &stderr),
 			Raw:     false,
 		}, &cfg)
 		Expect(err).NotTo(HaveOccurred())
@@ -33,13 +33,13 @@ var _ = Describe("config view", func() {
 		Expect(cfg).To(Equal(*originalCfg), "config value is modified")
 	})
 	It("raw output", func() {
-		stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
+		var stdin, stdout, stderr bytes.Buffer
 		originalCfg := config.NewTestPersistedConfig()
 		fillCfgWithMockValues(originalCfg)
 
 		cfg := *originalCfg
 		err := run(&ConfigViewOpts{
-			Streams: userio.NewIOStreams(&stdin, &stdout),
+			Streams: userio.NewIOStreams(&stdin, &stdout, &stderr),
 			Raw:     true,
 		}, &cfg)
 		Expect(err).NotTo(HaveOccurred())
@@ -53,17 +53,17 @@ var _ = Describe("config view", func() {
 		Expect(cfg).To(Equal(*originalCfg), "config value is modified")
 	})
 	It("config is not persisted", func() {
-		stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
+		var stdin, stdout, stderr bytes.Buffer
 		originalCfg := config.NewConfig()
 		fillCfgWithMockValues(originalCfg)
 
 		cfg := *originalCfg
 		err := run(&ConfigViewOpts{
-			Streams: userio.NewIOStreams(&stdin, &stdout),
+			Streams: userio.NewIOStreams(&stdin, &stdout, &stderr),
 			Raw:     false,
 		}, &cfg)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(stdout.String()).To(ContainSubstring("No config found"))
+		Expect(stderr.String()).To(ContainSubstring("No config found"))
 		Expect(cfg).To(Equal(*originalCfg), "config value is modified")
 	})
 })

--- a/pkg/cmd/env/connect.go
+++ b/pkg/cmd/env/connect.go
@@ -42,6 +42,7 @@ func connectCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return connect(opts, cfg)
 		},

--- a/pkg/cmd/env/list.go
+++ b/pkg/cmd/env/list.go
@@ -24,6 +24,7 @@ func listCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 
 			return list(opts, cfg)

--- a/pkg/cmd/env/open.go
+++ b/pkg/cmd/env/open.go
@@ -31,6 +31,7 @@ func openResource(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(cfg, &opts)
 		},

--- a/pkg/cmd/p2p/env/sync/env_sync.go
+++ b/pkg/cmd/p2p/env/sync/env_sync.go
@@ -37,6 +37,7 @@ func NewP2PSyncCmd(cfg *config.Config) (*cobra.Command, error) {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/p2p/export/export.go
+++ b/pkg/cmd/p2p/export/export.go
@@ -84,6 +84,7 @@ func NewP2PExportCmd(cfg *config.Config) (*cobra.Command, error) {
 			opts.streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(opts, cfg.Repositories.AllowDirty.Value, &cfg.Repositories.CPlatform)
 		},

--- a/pkg/cmd/p2p/export/export_test.go
+++ b/pkg/cmd/p2p/export/export_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var streams = userio.NewIOStreams(os.Stdin, os.Stdout)
+var streams = userio.NewIOStreams(os.Stdin, os.Stdout, os.Stderr)
 
 func TestMain(m *testing.M) {
 	log.DefaultLogger.SetLevel(log.PanicLevel)
@@ -25,17 +25,17 @@ func TestMain(m *testing.M) {
 }
 
 func TestRunExportPrintsEnvVarsToStdOut(t *testing.T) {
-	var output bytes.Buffer
+	var output, stderr bytes.Buffer
 
 	err := run(&exportOpts{
 		tenant:          testdata.DefaultTenant(),
 		environmentName: testdata.DevEnvironment(),
 		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
-		streams:         userio.NewIOStreams(os.Stdin, &output),
+		streams:         userio.NewIOStreams(os.Stdin, &output, &stderr),
 	}, false, &config.Parameter[string]{Value: testLocalRepo(t, testdata.CPlatformEnvsPath()).Path()})
 
 	assert.NoError(t, err)
-	assert.Contains(t, output.String(), "export", p2p.BaseDomain, p2p.Registry, p2p.Version, p2p.RepoPath, p2p.TenantName, p2p.Region)
+	assert.Contains(t, stderr.String(), "export", p2p.BaseDomain, p2p.Registry, p2p.Version, p2p.RepoPath, p2p.TenantName, p2p.Region)
 }
 
 func TestRunExportNonExistingAppRepo(t *testing.T) {

--- a/pkg/cmd/p2p/promote/p2p_promote.go
+++ b/pkg/cmd/p2p/promote/p2p_promote.go
@@ -43,6 +43,7 @@ func NewP2PPromoteCmd() (*cobra.Command, error) {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			opts.Exec = NewCommander(
 				WithStdout(cmd.OutOrStdout()),

--- a/pkg/cmd/p2p/promote/p2p_promote_test.go
+++ b/pkg/cmd/p2p/promote/p2p_promote_test.go
@@ -32,7 +32,7 @@ func Test_run(t *testing.T) {
 			DestStage:          "prod",
 			DestAuthOverride:   "/dest-auth.json",
 			Exec:               mockCommander,
-			Streams:            userio.NewIOStreams(os.Stdin, os.Stdout),
+			Streams:            userio.NewIOStreams(os.Stdin, os.Stdout, os.Stderr),
 			FileSystem:         mockFS,
 		}
 		err := run(opts)

--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -62,14 +62,16 @@ func NewRootCmd(cfg *config.Config) *cobra.Command {
 				ConfigureGlobalLogger(logLevel)
 				cmd.SilenceErrors = true
 
-				if cmd.Name() != update.CmdName {
+				cmdName := cmd.Name()
+				if cmdName != update.CmdName {
 					update.CheckForUpdates(cfg, cmd)
 				}
-				if !cfg.IsPersisted() && !(cmd.Name() == configcmd.CmdName) {
+				if !cfg.IsPersisted() && !(cmdName == configcmd.CmdName || cmdName == version.CmdName) {
 					styles := userio.NewNonInteractiveStyles()
 					streams := userio.NewIOStreamsWithInteractive(
 						os.Stdin,
 						os.Stdout,
+						os.Stderr,
 						false,
 					)
 					streams.Warn(

--- a/pkg/cmd/template/render/template_render.go
+++ b/pkg/cmd/template/render/template_render.go
@@ -30,7 +30,7 @@ func NewTemplateRenderCmd(cfg *config.Config) *cobra.Command {
 		Short: "Render template locally",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			opts.Streams = userio.NewIOStreams(cmd.InOrStdin(), cmd.OutOrStdout())
+			opts.Streams = userio.NewIOStreams(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.OutOrStderr())
 			opts.TemplateName = args[0]
 			opts.TargetPath = args[1]
 			opts.TemplatesPath = cfg.Repositories.Templates.Value

--- a/pkg/cmd/tenant/addrepo/tenant_add_repo.go
+++ b/pkg/cmd/tenant/addrepo/tenant_add_repo.go
@@ -33,6 +33,7 @@ func NewTenantAddRepoCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/tenant/create/tenant_create.go
+++ b/pkg/cmd/tenant/create/tenant_create.go
@@ -48,6 +48,7 @@ func NewTenantCreateCmd(cfg *config.Config) *cobra.Command {
 			opt.Streams = userio.NewIOStreamsWithInteractive(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 				!opt.NonInteractive,
 			)
 			return run(&opt, cfg)

--- a/pkg/cmd/tenant/describe/tenant_describe.go
+++ b/pkg/cmd/tenant/describe/tenant_describe.go
@@ -26,6 +26,7 @@ func NewTenantDescribeCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/tenant/list/tenant_list.go
+++ b/pkg/cmd/tenant/list/tenant_list.go
@@ -23,6 +23,7 @@ func NewTenantListCmd(cfg *config.Config) *cobra.Command {
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
 			)
 			return run(&opts, cfg)
 		},

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -120,6 +120,7 @@ func CheckForUpdates(cfg *config.Config, cmd *cobra.Command) {
 			streams := userio.NewIOStreamsWithInteractive(
 				os.Stdin,
 				os.Stdout,
+				os.Stderr,
 				false,
 			)
 
@@ -173,6 +174,7 @@ func UpdateCmd(cfg *config.Config) *cobra.Command {
 			opts.streams = userio.NewIOStreamsWithInteractive(
 				os.Stdin,
 				os.Stdout,
+				os.Stderr,
 				!nonInteractive,
 			)
 

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -320,8 +320,13 @@ func update(opts UpdateOpts) error {
 	// simulate the rename
 	err = moveFile(tmpPath, partialPath)
 	if err != nil {
-		wizard.Abort(err.Error())
-		return fmt.Errorf("could not move file to partial path %s: %+v", path, err)
+		if strings.Contains(err.Error(), "permission denied") {
+			wizard.Abort(fmt.Sprintf("Could not write to %s, try `sudo corectl update`", path))
+			return fmt.Errorf("could not move file to partial path, try `sudo corectl update %s: %+v", path, err)
+		} else {
+			wizard.Abort(err.Error())
+			return fmt.Errorf("could not move file to partial path %s: %+v", path, err)
+		}
 	}
 	err = os.Rename(partialPath, path)
 	if err != nil {

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -10,9 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const CmdName = "version"
+
 func VersionCmd(cfg *config.Config) *cobra.Command {
 	versionCmd := &cobra.Command{
-		Use:   "version",
+		Use:   CmdName,
 		Short: "List corectl version",
 		Long:  `This command allows you to list the currently running corectl version.`,
 		Args:  cobra.NoArgs,
@@ -20,6 +22,7 @@ func VersionCmd(cfg *config.Config) *cobra.Command {
 			streams := userio.NewIOStreamsWithInteractive(
 				os.Stdin,
 				os.Stdout,
+				os.Stderr,
 				false,
 			)
 			streams.Print(fmt.Sprintf("corectl %s (commit: %s) %s %s\n", version.Version, version.Commit, version.Date, version.Arch))

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -17,16 +17,12 @@ func VersionCmd(cfg *config.Config) *cobra.Command {
 		Long:  `This command allows you to list the currently running corectl version.`,
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _args []string) {
-			tag := version.Version
-			if tag != "untagged" {
-				tag = "v" + tag
-			}
 			streams := userio.NewIOStreamsWithInteractive(
 				os.Stdin,
 				os.Stdout,
 				false,
 			)
-			streams.Print(fmt.Sprintf("corectl %s (commit: %s) %s %s\n", tag, version.Commit, version.Date, version.Arch))
+			streams.Print(fmt.Sprintf("corectl %s (commit: %s) %s %s\n", version.Version, version.Commit, version.Date, version.Arch))
 		},
 	}
 

--- a/pkg/cmdutil/selector/input_test.go
+++ b/pkg/cmdutil/selector/input_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var streams = userio.NewIOStreams(os.Stdin, os.Stdout)
+var streams = userio.NewIOStreams(os.Stdin, os.Stdout, os.Stderr)
 
 func TestMain(m *testing.M) {
 	log.DefaultLogger.SetLevel(log.PanicLevel)

--- a/pkg/cmdutil/userio/file_picker.go
+++ b/pkg/cmdutil/userio/file_picker.go
@@ -30,7 +30,7 @@ func (ifp *FilePicker) GetInput(streams IOStreams) (string, error) {
 	expandedValue, err := expandPath(ifp.WorkingDir, initialValue)
 
 	model := textinput.New()
-	if streams.out.ColorProfile() != termenv.Ascii {
+	if streams.stdout.ColorProfile() != termenv.Ascii {
 		model.ShowSuggestions = true
 		model.PlaceholderStyle = streams.styles.suggestion
 		model.CompletionStyle = streams.styles.suggestion

--- a/pkg/cmdutil/userio/interop.go
+++ b/pkg/cmdutil/userio/interop.go
@@ -26,10 +26,10 @@ func (nonInteractiveHandler) OnQuit(model tea.Model, msg tea.Msg) tea.Msg {
 }
 
 func (nih nonInteractiveHandler) Info(message string) {
-	_, _ = nih.streams.outRaw.Write([]byte(nih.InfoLog(message) + "\n"))
+	_, _ = nih.streams.stdoutRaw.Write([]byte(nih.InfoLog(message) + "\n"))
 }
 func (nih nonInteractiveHandler) Warn(message string) {
-	_, _ = nih.streams.outRaw.Write([]byte(nih.WarnLog(message) + "\n"))
+	_, _ = nih.streams.stdoutRaw.Write([]byte(nih.WarnLog(message) + "\n"))
 }
 func (nih nonInteractiveHandler) SetTask(title string, _ string) {
 	nih.Info(fmt.Sprintf("[%s]", nih.styles.Bold.Render(title)))

--- a/pkg/cmdutil/userio/output.go
+++ b/pkg/cmdutil/userio/output.go
@@ -10,13 +10,13 @@ import (
 	"github.com/phuslu/log"
 )
 
-func (s IOStreams) MsgE(message string, style lipgloss.Style) error {
-	_, err := s.out.Output().Write([]byte(style.Render(message)))
+func (s IOStreams) MsgE(message string, style lipgloss.Style, stream *lipgloss.Renderer) error {
+	_, err := stream.Output().Write([]byte(style.Render(message)))
 	if err != nil {
 		return fmt.Errorf("couldn't output info message: %v", err)
 	}
 	if !strings.HasSuffix(message, "\n") {
-		if _, err = s.out.Output().Write([]byte("\n")); err != nil {
+		if _, err = stream.Output().Write([]byte("\n")); err != nil {
 			return fmt.Errorf("couldn't output info message: %v", err)
 		}
 	}
@@ -24,28 +24,28 @@ func (s IOStreams) MsgE(message string, style lipgloss.Style) error {
 }
 
 func (s IOStreams) Print(messages string) {
-	err := s.MsgE(messages, lipgloss.NewStyle())
+	err := s.MsgE(messages, lipgloss.NewStyle(), s.stdout)
 	if err != nil {
 		panic(err.Error())
 	}
 }
 
 func (s IOStreams) Info(messages string) {
-	err := s.MsgE(messages, s.styles.info)
+	err := s.MsgE(messages, s.styles.info, s.stderr)
 	if err != nil {
 		panic(err.Error())
 	}
 }
 
 func (s IOStreams) Warn(messages string) {
-	err := s.MsgE(messages, s.styles.warn)
+	err := s.MsgE(messages, s.styles.warn, s.stderr)
 	if err != nil {
 		panic(err.Error())
 	}
 }
 
 func (s IOStreams) Error(messages string) {
-	err := s.MsgE(messages, s.styles.err)
+	err := s.MsgE(messages, s.styles.err, s.stderr)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/pkg/cmdutil/userio/prompt_mock.go
+++ b/pkg/cmdutil/userio/prompt_mock.go
@@ -1,11 +1,12 @@
 package userio
 
 import (
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 	"io"
 	"os"
 	"slices"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 )
 
 type testEnviron struct{}
@@ -28,8 +29,8 @@ func NewTestIOStreams(in io.Reader, out io.Writer, isInteractive bool) IOStreams
 		termenv.WithEnvironment(testEnviron{}),
 	)
 	return IOStreams{
-		in:            in,
-		out:           renderer,
+		stdin:         in,
+		stdout:        renderer,
 		styles:        newStyles(renderer),
 		isInteractive: isInteractive,
 	}

--- a/pkg/cmdutil/userio/text_input.go
+++ b/pkg/cmdutil/userio/text_input.go
@@ -32,7 +32,7 @@ func (ti *TextInput[V]) GetInput(streams IOStreams) (V, error) {
 		panic("ValidateAndMap is required")
 	}
 	model := textinput.New()
-	if streams.out.ColorProfile() != termenv.Ascii {
+	if streams.stdout.ColorProfile() != termenv.Ascii {
 		model.Placeholder = ti.Placeholder
 		model.PlaceholderStyle = streams.styles.suggestion
 		model.CompletionStyle = streams.styles.suggestion

--- a/pkg/env/connect_test.go
+++ b/pkg/env/connect_test.go
@@ -1,10 +1,11 @@
 package env
 
 import (
-	"github.com/coreeng/corectl/pkg/command"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/coreeng/corectl/pkg/command"
 
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/developer-platform/pkg/environment"
@@ -23,6 +24,7 @@ func TestConnectSuccess(t *testing.T) {
 	streams := userio.NewIOStreams(
 		os.Stdin,
 		os.Stdout,
+		os.Stderr,
 	)
 	err := Connect(streams, env, mockCommanderSuccess{}, proxy)
 	assert.NoError(t, err)
@@ -40,6 +42,7 @@ func TestConnectFail(t *testing.T) {
 	streams := userio.NewIOStreams(
 		os.Stdin,
 		os.Stdout,
+		os.Stderr,
 	)
 	err := Connect(streams, env, mockCommanderFail{}, proxy)
 	assert.Error(t, err)

--- a/pkg/env/list_test.go
+++ b/pkg/env/list_test.go
@@ -45,6 +45,7 @@ NAME        ID                   CLOUD PLATFORM
 	streams := userio.NewIOStreams(
 		os.Stdin,
 		os.Stdout,
+		os.Stderr,
 	)
 
 	for _, tt := range tests {
@@ -95,6 +96,7 @@ NAME          ID    CLOUD PLATFORM
 	streams := userio.NewIOStreams(
 		os.Stdin,
 		os.Stdout,
+		os.Stderr,
 	)
 
 	for _, tt := range tests {

--- a/pkg/tenant/list_test.go
+++ b/pkg/tenant/list_test.go
@@ -2,6 +2,7 @@ package tenant
 
 import (
 	"bytes"
+
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	coretnt "github.com/coreeng/developer-platform/pkg/tenant"
 	. "github.com/onsi/ginkgo/v2"
@@ -11,8 +12,8 @@ import (
 var _ = Describe("tenant table", func() {
 	DescribeTable("render",
 		func(tenants []coretnt.Tenant, expectedOutput string) {
-			stdin, stdout := bytes.Buffer{}, bytes.Buffer{}
-			streams := userio.NewIOStreams(&stdin, &stdout)
+			var stdin, stdout, stderr bytes.Buffer
+			streams := userio.NewIOStreams(&stdin, &stdout, &stderr)
 			table := NewTable(streams)
 			for _, t := range tenants {
 				table.AppendRow(t)


### PR DESCRIPTION
### 🚀 Features

- *(logs)* iostreams.info/warn/error maps to stderr, iostreams.print maps to stdout
- *(update)* hint to use sudo if permissions are denied to target binary path in `update`

### 🐛 Bug Fixes

- *(release)* Use Tag instead of Version as version label, this fixes `update` always notifying of a new version
- *(version)* Do not warn about config being unset in `version` command
