### PR TITLE
feat(cliff): Add git-cliff for automated release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,92 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+# Remote for git-cliff
+[remote.github]
+owner = "coreeng"
+repo = "corectl"
+[changelog]
+# changelog header
+header = ""
+# template for the changelog body
+# https://tera.netlify.app/docs
+body = """
+**Docker Image**: {{ get_env(name='REGISTRY', default='ghcr.io') }}/{{get_env(name='ORG', default='coreend')}}/{{ get_env(name='IMAG_NAME', default='corectl') }}:{{ get_env(name='GITHUB_REF_NAME', default='latest') }}
+
+### Changelog \
+{% for group, commits in commits | group_by(attribute="group") %}
+    \n#### {{ group | striptags | trim | upper_first }}:
+    {% for commit in commits
+    | filter(attribute="group")
+    | unique(attribute="message")
+    | filter(attribute="merge_commit", value=false) %}
+        - {{commit.scope}}: \
+            {{ commit.message }}\
+            {% if not commit.github.pr_number %} []({{ self::remote_url() }}/commit/{{ commit.id }}){%- endif %}\
+            {% if commit.github.username %} by @{{ commit.github.username }}\
+            {% else %} by [{{ commit.author.name }}](https://github.com/{{ commit.author.name }}){%- endif %}\
+    {%- endfor -%}
+{% endfor %}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+### New Contributors
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  * @{{ contributor.username }} made their first contribution {% if contributor.pr_number %} in #{{ contributor.pr_number }} {%- endif %}
+{%- endfor -%}
+{%- endif %}
+
+Full Changelog: [{{ previous.version }}...{{ version }}]({{ self::remote_url() }}/compare/{{ previous.version }}...{{ version }})
+
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+# changelog footer
+footer = ""
+# postprocessors
+postprocessors = [
+  # { pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" }, # replace repository URL
+]
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+  # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"}, # replace issue numbers
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = "^(refactor|ref)", group = "Internal/Other", scope="ref" },
+  { message = "^build", group = "Internal/Other", scope="build" },
+  { message = "^chore", group = "Internal/Other", scope="chore" },
+  { message = "^ci", group = "Internal/Other", scope="ci" },
+  { message = "^dep", group = "Internal/Other", scope="dep" },
+  { message = "^doc", group = "Internal/Other", scope="doc" },
+  { message = "^feat", group = "Features", scope="feat" },
+  { message = "^fix", group = "Fixes", scope="fix" },
+  { message = "^perf", group = "Internal/Other", scope="perf" },
+  { message = "^style", group = "Internal/Other", scope="style" },
+  { message = "^test", group = "Internal/Other", scope="test" },
+  { body = ".*security", group = "Internal/Other", scope="sec" },
+  { message = "^revert", group = "Internal/Other", scope="revert" },
+]
+# protect breaking changes from being skipped due to matching a skipping commit_parser
+protect_breaking_commits = false
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "^v[0-9]+.[0-9]+.[0-9]+$"
+# regex for skipping tags
+skip_tags = "^nightly-.*"
+# regex for ignoring tags
+ignore_tags = "^nightly-.*"
+# sort the tags topologically
+topo_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"
+# limit the number of commits included in the changelog.
+# limit_commits = 42


### PR DESCRIPTION
This pr adds [git-cliff](https://git-cliff.org/) for automated release notes.

Signed-off-by: dark0dave <dark0dave@mykolab.com>
