### PR TITLE
fix(build): Fix linting, so CI fails

### DIFF
--- a/.github/workflows/fastfeedback.yaml
+++ b/.github/workflows/fastfeedback.yaml
@@ -30,10 +30,9 @@ jobs:
           git config --global url."https://${GH_ACCESS_TOKEN}@github.com/coreeng".insteadOf "https://github.com/coreeng"
           go mod download
       - name: lint
-        uses: reviewdog/action-golangci-lint@v2
+        uses: golangci/golangci-lint-action@v6
         with:
-          go_version_file: 'go.mod'
-          golangci_lint_flags: --timeout 3m --verbose
+          args: --timeout=3m
       - name: test
         run: |
           git config --global user.name "Test Bot"

--- a/pkg/cmdutil/userio/styles.go
+++ b/pkg/cmdutil/userio/styles.go
@@ -7,7 +7,6 @@ import (
 
 var (
 	blueColor = lipgloss.Color("51")
-	redColor  = lipgloss.Color("124")
 )
 
 type styles struct {


### PR DESCRIPTION
Add ci, as the build was actaully not building the binary. And fail if golang-ci lint fails.
Fixes https://github.com/orgs/coreeng/projects/32/views/1?pane=issue&itemId=86172026&issue=coreeng%7Cproject-platform-accelerator%7C506