### PR TITLE
Remove duplicate definitions on app commands.

### DIFF
--- a/pkg/cmd/root/root.go
+++ b/pkg/cmd/root/root.go
@@ -2,12 +2,12 @@ package root
 
 import (
 	"fmt"
+	"github.com/coreeng/corectl/pkg/cmd/env"
 	"os"
 	"time"
 
 	"github.com/coreeng/corectl/pkg/cmd/application"
 	configcmd "github.com/coreeng/corectl/pkg/cmd/config"
-	"github.com/coreeng/corectl/pkg/cmd/env"
 	"github.com/coreeng/corectl/pkg/cmd/p2p"
 	"github.com/coreeng/corectl/pkg/cmd/template"
 	"github.com/coreeng/corectl/pkg/cmd/tenant"
@@ -129,15 +129,13 @@ func NewRootCmd(cfg *config.Config) *cobra.Command {
 	}
 	rootCmd.AddCommand(appCmd)
 	rootCmd.AddCommand(p2pCmd)
+	
 	rootCmd.AddCommand(configcmd.NewConfigCmd(cfg))
+	rootCmd.AddCommand(env.NewEnvCmd(cfg))
 	rootCmd.AddCommand(tenant.NewTenantCmd(cfg))
 	rootCmd.AddCommand(template.NewTemplateCmd(cfg))
-	rootCmd.AddCommand(env.NewEnvCmd(cfg))
-	rootCmd.AddCommand(version.VersionCmd(cfg))
 	rootCmd.AddCommand(update.UpdateCmd(cfg))
-	rootCmd.AddCommand(configcmd.NewConfigCmd(cfg))
 	rootCmd.AddCommand(version.VersionCmd(cfg))
-	rootCmd.AddCommand(update.UpdateCmd(cfg))
 
 	return rootCmd
 }


### PR DESCRIPTION
Some of the subcommands are currently included twice. Remove the duplicates and keep them in order to make duplicates more obvious.

```console
CLI interface for the CECG core platform.

Usage:
  corectl [flags]
  corectl [command]

Available Commands:
  apps        Operations with applications
  completion  Generate the autocompletion script for the specified shell
  config      corectl configuration management operations
  config      corectl configuration management operations
  env         Work with Platform Environments
  help        Help about any command
  p2p         P2P Operations
  template    Operations with templates
  tenants     Operations with tenants
  update      Update corectl
  update      Update corectl
  version     List corectl version
  version     List corectl version

Flags:
  -h, --help               help for corectl
  -l, --log-level string   Log level - writes to ./corectl.log if set (default "disabled")
      --non-interactive    Run in non-interactive mode - the command will error if it needs to ask for user input

Use "corectl [command] --help" for more information about a command.
```
