### PR TITLE
Disable showing usage once processing begins

### DIFF
--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -55,6 +55,7 @@ NOTE:
 `,
 		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Name = args[0]
 			if len(args) > 1 {
 				opts.LocalPath = args[1]

--- a/pkg/cmd/config/init/config_init.go
+++ b/pkg/cmd/config/init/config_init.go
@@ -42,6 +42,7 @@ func NewConfigInitCmd(cfg *config.Config) *cobra.Command {
 		Use:   "init",
 		Short: "Initialize corectl before work",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			nonInteractive, err := cmd.Flags().GetBool("non-interactive")
 			if err != nil {
 				log.Panic().Err(err).Msg("could not get non-interactive flag")

--- a/pkg/cmd/config/set/config_set.go
+++ b/pkg/cmd/config/set/config_set.go
@@ -22,6 +22,7 @@ func NewConfigSetCmd(cfg *config.Config) *cobra.Command {
 		Short: "Set configuration parameters",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Path = args[0]
 			opts.Value = args[1]
 			opts.Streams = userio.NewIOStreams(

--- a/pkg/cmd/config/update/config_update.go
+++ b/pkg/cmd/config/update/config_update.go
@@ -20,6 +20,7 @@ func NewConfigUpdateCmd(cfg *config.Config) *cobra.Command {
 		Short: "Pull updates from remote repositories",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),

--- a/pkg/cmd/config/view/config_view.go
+++ b/pkg/cmd/config/view/config_view.go
@@ -21,6 +21,7 @@ func NewConfigViewCmd(cfg *config.Config) *cobra.Command {
 		Short: "Displays local corectl configuration",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),

--- a/pkg/cmd/p2p/env/sync/env_sync.go
+++ b/pkg/cmd/p2p/env/sync/env_sync.go
@@ -31,6 +31,7 @@ func NewP2PSyncCmd(cfg *config.Config) (*cobra.Command, error) {
 		Short: "Synchronise Environments",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.AppRepo = args[0]
 			opts.Tenant = args[1]
 

--- a/pkg/cmd/p2p/export/export.go
+++ b/pkg/cmd/p2p/export/export.go
@@ -81,6 +81,7 @@ func NewP2PExportCmd(cfg *config.Config) (*cobra.Command, error) {
 		Use:   "export",
 		Short: "Produce export statements for environment variables required to execute p2p targets, to automatically export in current shell run 'eval $(corectl p2p export [flags])'",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),

--- a/pkg/cmd/p2p/promote/p2p_promote.go
+++ b/pkg/cmd/p2p/promote/p2p_promote.go
@@ -39,6 +39,7 @@ func NewP2PPromoteCmd() (*cobra.Command, error) {
 		Short: "Promotes image from source to destination registry. Only GCP is supported for now",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.ImageWithTag = args[0]
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),

--- a/pkg/cmd/template/describe/template_describe.go
+++ b/pkg/cmd/template/describe/template_describe.go
@@ -21,6 +21,7 @@ func NewTemplateDescribeCmd(cfg *config.Config) *cobra.Command {
 		Short: "Show detailed information about passed template",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			templateName := args[0]
 			if !opts.IgnoreChecks {
 				if _, err := config.ResetConfigRepositoryState(&cfg.Repositories.Templates, false); err != nil {

--- a/pkg/cmd/template/list/template_list.go
+++ b/pkg/cmd/template/list/template_list.go
@@ -18,6 +18,7 @@ func NewTemplateListCmd(cfg *config.Config) *cobra.Command {
 		Use:   "list",
 		Short: "List templates",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if !opts.IgnoreChecks {
 				if _, err := config.ResetConfigRepositoryState(&cfg.Repositories.Templates, false); err != nil {
 					return err

--- a/pkg/cmd/template/render/template_render.go
+++ b/pkg/cmd/template/render/template_render.go
@@ -30,6 +30,7 @@ func NewTemplateRenderCmd(cfg *config.Config) *cobra.Command {
 		Short: "Render template locally",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Streams = userio.NewIOStreams(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.OutOrStderr())
 			opts.TemplateName = args[0]
 			opts.TargetPath = args[1]

--- a/pkg/cmd/tenant/addrepo/tenant_add_repo.go
+++ b/pkg/cmd/tenant/addrepo/tenant_add_repo.go
@@ -27,6 +27,7 @@ func NewTenantAddRepoCmd(cfg *config.Config) *cobra.Command {
 		Short: "Add a repository to the tenant",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			// TODO: Change this to named params, and use same GetInput prompts as `apps create`
 			opts.TenantName = args[0]
 			opts.RepositoryUrl = args[1]

--- a/pkg/cmd/tenant/create/tenant_create.go
+++ b/pkg/cmd/tenant/create/tenant_create.go
@@ -41,6 +41,7 @@ func NewTenantCreateCmd(cfg *config.Config) *cobra.Command {
 		Use:   "create",
 		Short: "Creates tenant",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			nonInteractive, err := cmd.Flags().GetBool("non-interactive")
 			if err != nil {
 				log.Panic().Err(err).Msg("could not get non-interactive flag")

--- a/pkg/cmd/tenant/describe/tenant_describe.go
+++ b/pkg/cmd/tenant/describe/tenant_describe.go
@@ -22,6 +22,7 @@ func NewTenantDescribeCmd(cfg *config.Config) *cobra.Command {
 		Short: "Describe tenant",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.TenantName = args[0]
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),

--- a/pkg/cmd/tenant/list/tenant_list.go
+++ b/pkg/cmd/tenant/list/tenant_list.go
@@ -20,6 +20,7 @@ func NewTenantListCmd(cfg *config.Config) *cobra.Command {
 		Use:   "list",
 		Short: "List tenants",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			opts.Streams = userio.NewIOStreams(
 				cmd.InOrStdin(),
 				cmd.OutOrStdout(),

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -161,6 +161,7 @@ func UpdateCmd(cfg *config.Config) *cobra.Command {
 		Long:  `Update to the latest corectl version.`,
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
 			if len(args) > 0 {
 				opts.targetVersion = args[0]
 			}


### PR DESCRIPTION
At present if an error occurs by default corectl will show the usage message.

Generally speaking the usage message should only be shown if there is seen to be an error in how corectl is invoked. It should not be shown if there is a semantic error further in processing, like if the environment/tenant is specified incorrectly, or a connection to a downstream system fails.

The cobra setting `cmd.SilenceUsage = true` disables this behaviour. This has been applied to all of the existing commands at the beginning of their run block.If subsequently it is deemed beneficial for any specific use case beyond this, it is simple enough to change on a case by case basis.
