### PR TITLE
Improve env connect logging output and reduce verbosity

### DIFF
--- a/pkg/cmd/env/active.go
+++ b/pkg/cmd/env/active.go
@@ -105,7 +105,7 @@ func activeCmd(cfg *config.Config) *cobra.Command {
 
 func active(opts ActiveOpt, environments []environment.Environment) error {
 	// Call getProxyPids to get pids
-	pids, err := corectlenv.GetProxyPIDs(environments)
+	pids, err := corectlenv.GetProxyPids(environments)
 	_ = err
 
 	table := corectlenv.NewTable(opts.Streams, true)

--- a/pkg/cmd/env/disconnect.go
+++ b/pkg/cmd/env/disconnect.go
@@ -10,6 +10,8 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/command"
 	corectlenv "github.com/coreeng/corectl/pkg/env"
+	"github.com/coreeng/corectl/pkg/logger"
+
 	"github.com/spf13/cobra"
 )
 
@@ -89,14 +91,14 @@ func disconnectCmd(cfg *config.Config) *cobra.Command {
 
 func disconnect(opts corectlenv.EnvConnectOpts, cfg *config.Config, environments []environment.Environment) error {
 	// Call getProxyPids to get pids
-	pids, err := corectlenv.GetProxyPIDs(environments)
+	pids, err := corectlenv.GetProxyPids(environments)
 	_ = err
 	for name, pid := range pids {
 		// Kill the process with the pid
 		if err := corectlenv.KillProcess(name, pid.Pid, false); err != nil {
 			return fmt.Errorf("[%s] failed to kill process: %w", name, err)
 		}
-		opts.Streams.Info(fmt.Sprintf("[%s] killed process %d on port %d", name, pid.Pid, pid.Port))
+		logger.Warn().Msgf("Proxy for %s with pid %d stopped", name, pid.Pid)
 	}
 	return nil
 }

--- a/pkg/env/connect.go
+++ b/pkg/env/connect.go
@@ -51,7 +51,7 @@ func Connect(opts EnvConnectOpts) error {
 		existingPid := ExistingPidForConnection(opts.Environment.Environment)
 		if existingPid != 0 {
 			if !opts.Force {
-				s.Info(fmt.Sprintf("connection already exists for environment %s with pid %d", opts.Environment.Environment, existingPid))
+				logger.Warn().Msgf("Proxy for %s already running with pid %d", opts.Environment.Environment, existingPid)
 				return nil
 			}
 			if err := KillProcess(opts.Environment.Environment, int32(existingPid), false); err != nil {
@@ -156,16 +156,16 @@ func setupConnection(streams userio.IOStreams, opts EnvConnectOpts, c Commander,
 		return proxyUrl, nil
 	}
 
-	logger.Warn().Msgf("Retrieving cluster credentials: project=%s zone=%s cluster=%s", e.ProjectId, e.Region, env.Environment)
+	logger.Info().Msgf("Retrieving cluster credentials: project=%s zone=%s cluster=%s", e.ProjectId, e.Region, env.Environment)
 
 	if err := setCredentials(c, env.Environment, e.ProjectId, e.Region); err != nil {
 		logger.Error().Msg(err.Error())
 		return "", err
 	}
-	logger.Warn().Msgf("Configured cluster credentials: project=%s zone=%s cluster=%s", e.ProjectId, e.Region, env.Environment)
+	logger.Info().Msgf("Configured cluster credentials: project=%s zone=%s cluster=%s", e.ProjectId, e.Region, env.Environment)
 
 	context := fmt.Sprintf("gke_%s_%s_%s", e.ProjectId, e.Region, env.Environment)
-	logger.Warn().Msgf("Setting Kubernetes config context to: %s", context)
+	logger.Info().Msgf("Setting Kubernetes config context to: %s", context)
 
 	if err := setKubeContext(c, context); err != nil {
 		logger.Error().Msg(err.Error())
@@ -173,13 +173,13 @@ func setupConnection(streams userio.IOStreams, opts EnvConnectOpts, c Commander,
 	}
 	logger.Warn().Msgf("Kubernetes config context set to: %s", context)
 
-	logger.Warn().Msgf("Setting Kubernetes proxy url to: %s", proxyUrl)
+	logger.Info().Msgf("Setting Kubernetes proxy url to: %s", proxyUrl)
 	if err := setKubeProxy(c, context, proxyUrl); err != nil {
 		logger.Error().Msg(err.Error())
 		return "", err
 	}
 
-	logger.Warn().Msgf("Kubernetes proxy url set to: %s", proxyUrl)
+	logger.Info().Msgf("Kubernetes proxy url set to: %s", proxyUrl)
 	return proxyUrl, nil
 }
 

--- a/pkg/env/proxy.go
+++ b/pkg/env/proxy.go
@@ -21,21 +21,21 @@ func Listen(streams userio.IOStreams, opts EnvConnectOpts, ctx context.Context, 
 	var err error
 
 	if IsConnectStartup(opts) { // Common code for foreground and background
-		logger.Warn().Msg("Testing IAP connection")
+		logger.Info().Msg("Testing IAP connection")
 		if err := testConn(ctx, dialOpts); err != nil {
 			err = fmt.Errorf("failed to test connection: %w", err)
 			logger.Fatal().Msg(err.Error())
 		}
-		logger.Warn().Msg("IAP connection succeeded")
+		logger.Info().Msg("IAP connection succeeded")
+
+		logger.Info().Msgf("Binding to %s", listen)
 		listener, err = net.Listen("tcp", listen)
-
-		logger.Warn().Msgf("Binding to %s", listen)
-
 		if err != nil {
 			logger.Fatal().With(zap.Error(err)).Msgf("failed to bind to %s", listen)
 			return
 		}
-		logger.Warn().Msgf("Bound to %s", listen)
+
+		logger.Warn().Msgf("Proxy for %s listening at %s", opts.Environment.Environment, listen)
 		if !opts.Background {
 			WritePidFile(opts.Environment.Environment, os.Getpid())
 		}
@@ -61,7 +61,7 @@ func Listen(streams userio.IOStreams, opts EnvConnectOpts, ctx context.Context, 
 			logger.Fatal().With(zap.Error(err)).Msg("failed to start background process")
 		}
 		WritePidFile(opts.Environment.Environment, cmd.Process.Pid)
-		logger.Warn().Msgf("Process started for %s in background with PID %d",
+		logger.Warn().Msgf("Proxy for %s running in the background with pid %d",
 			opts.Environment.Environment, cmd.Process.Pid)
 
 		return

--- a/pkg/env/util.go
+++ b/pkg/env/util.go
@@ -61,7 +61,7 @@ func ExistingPidForConnection(name string) int {
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
 	if err != nil {
-		log.Printf("failed to parse PID from file %s: %v", filename, err)
+		log.Printf("failed to parse pid from file %s: %v", filename, err)
 		return 0
 	}
 	// This is a pain but os.FindProcess always returns a process even if it doesn't exist
@@ -124,7 +124,7 @@ func GenerateConnectPort(name string) int {
 
 // Get a structure to represent the pids from a directory keyed by filename
 
-func GetProxyPIDs(availableEnvironments []environment.Environment) (map[string]ProcessDetails, error) {
+func GetProxyPids(availableEnvironments []environment.Environment) (map[string]ProcessDetails, error) {
 	files, err := os.ReadDir(PidFileDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory: %w", err)
@@ -156,7 +156,7 @@ func GetProxyPIDs(availableEnvironments []environment.Environment) (map[string]P
 
 		pid, err := strconv.Atoi(strings.TrimSpace(string(content)))
 		if err != nil {
-			log.Printf("failed to parse PID from file %s: %v", file.Name(), err)
+			log.Printf("failed to parse pid from file %s: %v", file.Name(), err)
 			continue
 		}
 		exists := false


### PR DESCRIPTION
Sample output:
```
$ corectl env active                      
 NAME  ID  CLOUDPLATFORM  PROXY  PID 
$ corectl env connect gcp-dev             
Kubernetes config context set to: gke_core-platform-efb3c84c_europe-west2_gcp-dev
Proxy for gcp-dev listening at localhost:37026
^C
$ corectl env connect gcp-dev --background
Kubernetes config context set to: gke_core-platform-efb3c84c_europe-west2_gcp-dev
Proxy for gcp-dev listening at localhost:37026
Proxy for gcp-dev running in the background with pid 76685
$ corectl env connect gcp-dev --background
Proxy for gcp-dev already running with pid 76685
$ corectl env disconnect gcp-dev          
Proxy for gcp-dev with pid 76685 stopped
$ corectl env disconnect gcp-dev
$ 
```