### PR TITLE
Switch from iap tunnel to dns endpoint

### DIFF
--- a/pkg/cmd/env/connect.go
+++ b/pkg/cmd/env/connect.go
@@ -38,6 +38,7 @@ func findEnvironmentByName(name string, environments []environment.Environment) 
 
 func connectCmd(cfg *config.Config) *cobra.Command {
 	opts := corectlenv.EnvConnectOpts{
+		SkipTunnel: true,
 		SilentExec: command.NewCommander(
 			command.WithStdout(&bytes.Buffer{}),
 			command.WithStderr(&bytes.Buffer{}),

--- a/pkg/env/connect.go
+++ b/pkg/env/connect.go
@@ -173,18 +173,21 @@ func setupConnection(streams userio.IOStreams, opts EnvConnectOpts, c Commander,
 	}
 	logger.Warn().Msgf("Kubernetes config context set to: %s", context)
 
-	logger.Info().Msgf("Setting Kubernetes proxy url to: %s", proxyUrl)
-	if err := setKubeProxy(c, context, proxyUrl); err != nil {
-		logger.Error().Msg(err.Error())
-		return "", err
+	if !opts.SkipTunnel {
+		logger.Info().Msgf("Setting Kubernetes proxy url to: %s", proxyUrl)
+		if err := setKubeProxy(c, context, proxyUrl); err != nil {
+			logger.Error().Msg(err.Error())
+			return "", err
+		}
+
+		logger.Info().Msgf("Kubernetes proxy url set to: %s", proxyUrl)
 	}
 
-	logger.Info().Msgf("Kubernetes proxy url set to: %s", proxyUrl)
 	return proxyUrl, nil
 }
 
 func setCredentials(c Commander, cluster, projectID, region string) error {
-	if _, err := c.Execute("gcloud", WithArgs("container", "clusters", "get-credentials", "--project", projectID, "--zone", region, "--internal-ip", cluster)); err != nil {
+	if _, err := c.Execute("gcloud", WithArgs("container", "clusters", "get-credentials", "--project", projectID, "--zone", region, "--dns-endpoint", cluster)); err != nil {
 		return fmt.Errorf("get gcp cluster credentials: %w", err)
 	}
 	return nil


### PR DESCRIPTION
- sets existing SkipTunnel env connection option to true by default
- also uses the above to conditionally set up the proxy via the tunnel