### PR TITLE
Show changelogs for multiple outstanding releases (Closes #546)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ corectl
 corectl*.log
 dist/
 .vscode
+.idea

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/gofrs/flock v0.12.1 // indirect
 	github.com/google/go-github/v59 v59.0.0 // indirect
 	github.com/mmcloughlin/avo v0.6.0 // indirect
@@ -52,7 +53,6 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.7 // indirect
 	cloud.google.com/go/compute/metadata v0.6.0 // indirect
 	dario.cat/mergo v1.0.1 // indirect
-	github.com/Masterminds/semver/v3 v3.3.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.5 // indirect
 	github.com/alecthomas/chroma/v2 v2.15.0 // indirect

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -219,7 +219,7 @@ func update(opts UpdateOpts) error {
 
 	currentVersion, parseCurrentErr := version.BuildReleaseVersion(version.Version)
 	if parseCurrentErr != nil {
-		logger.Warn().Msgf("could not parse current version: %v, defaulting to 0.0.0", parseCurrentErr)
+		logger.Warn().Msgf("could not parse current version %s: %v, defaulting to 0.0.0", version.Version, parseCurrentErr)
 		if currentVersion, parseCurrentErr = version.BuildReleaseVersion("0.0.0"); parseCurrentErr != nil {
 			return parseCurrentErr
 		}
@@ -270,7 +270,7 @@ func update(opts UpdateOpts) error {
 		logger.Warn().Msgf("Target version %s is behind the current version %s", targetVersion.String(), currentVersion.String())
 	} else if currentVersion.IsTargetVersionAhead(targetVersion) {
 		isAhead = true
-		logger.Warn().Msgf("Update available: %s", targetVersion.String())
+		logger.Warn().Msgf("Update available: v%s", targetVersion.String())
 	}
 
 	// fetch and render the changelogs for each missed release (max 10 most recent)
@@ -279,6 +279,11 @@ func update(opts UpdateOpts) error {
 		if err != nil {
 			logger.Error().Msg(err.Error())
 			return err
+		}
+		if len(outstandingReleases) == 10 {
+			logger.Warn().Msg("Showing Changelogs for the 10 most recent releases:")
+		} else {
+			logger.Warn().Msgf("Showing Changelogs for %d new releases:", len(outstandingReleases))
 		}
 		for _, release := range outstandingReleases {
 			var changelog = fmt.Sprintf("# Changelog for %s:\n%s", *release.TagName, *release.Body)

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -275,7 +275,7 @@ func update(opts UpdateOpts) error {
 
 	// fetch and render the changelogs for each missed release (max 10 most recent)
 	if isAhead {
-		outstandingReleases, err := listOutstandingReleasesSince(githubClient, version.Version, nil)
+		outstandingReleases, err := listOutstandingReleases(githubClient, version.Version, nil)
 		if err != nil {
 			logger.Error().Msg(err.Error())
 			return err
@@ -416,7 +416,7 @@ type ListOutstandingReleasesOpts struct {
 	PageSize int
 }
 
-func listOutstandingReleasesSince(client *github.Client, version string, opts *ListOutstandingReleasesOpts) ([]*github.RepositoryRelease, error) {
+func listOutstandingReleases(client *github.Client, version string, opts *ListOutstandingReleasesOpts) ([]*github.RepositoryRelease, error) {
 	defaultOpts := ListOutstandingReleasesOpts{Pages: 1, PageSize: 10}
 	if opts == nil {
 		opts = &defaultOpts

--- a/pkg/cmd/update/update.go
+++ b/pkg/cmd/update/update.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/Masterminds/semver/v3"
 	"io"
 	"net/http"
 	"os"
@@ -199,7 +200,7 @@ func updateAvailable(githubClient *github.Client) (bool, string, error) {
 	if err != nil {
 		return false, "", err
 	}
-	asset, err := getLatestCorectlAsset(release)
+	asset, err := getReleaseCorectlAsset(release)
 	if err != nil {
 		return false, "", err
 	}
@@ -211,9 +212,71 @@ func updateAvailable(githubClient *github.Client) (bool, string, error) {
 	}
 }
 
+type ReleaseVersion struct{ current *semver.Version }
+
+func (v ReleaseVersion) String() string {
+	return v.current.String()
+}
+
+func (v ReleaseVersion) isTargetVersionAhead(target *semver.Version) bool {
+	return v.current.LessThan(target)
+}
+
+func (v ReleaseVersion) isTargetVersionStringAhead(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.isTargetVersionAhead(parsedTarget), nil
+}
+
+func (v ReleaseVersion) isTargetVersionBehind(target *semver.Version) bool {
+	return v.current.GreaterThan(target)
+}
+
+func (v ReleaseVersion) isTargetVersionStringBehind(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.isTargetVersionBehind(parsedTarget), nil
+}
+
+func (v ReleaseVersion) isTargetVersionCurrent(target *semver.Version) bool {
+	return v.current.Equal(target)
+}
+
+func (v ReleaseVersion) isTargetVersionStringCurrent(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.isTargetVersionCurrent(parsedTarget), nil
+}
+
+func BuildReleaseVersion(version string) (ReleaseVersion, error) {
+	parsedVersion, parseErr := semver.NewVersion(version)
+	if parseErr != nil {
+		return ReleaseVersion{}, parseErr
+	}
+
+	return ReleaseVersion{parsedVersion}, nil
+}
+
 func update(opts UpdateOpts) error {
 	if opts.targetVersion != "" {
 		logger.Debug().Msgf("target version set to %s", opts.targetVersion)
+	}
+
+	currentVersion, parseCurrentErr := BuildReleaseVersion(version.Version)
+	if parseCurrentErr != nil {
+		logger.Warn().Msgf("could not parse current version: %v, defaulting to 0.0.0", parseCurrentErr)
+		if currentVersion, parseCurrentErr = BuildReleaseVersion("0.0.0"); parseCurrentErr != nil {
+			return parseCurrentErr
+		}
 	}
 
 	logger.Warn().Msg("Checking for updates")
@@ -222,37 +285,65 @@ func update(opts UpdateOpts) error {
 		githubClient = githubClient.WithAuthToken(opts.githubToken)
 	}
 
-	var release *github.RepositoryRelease
-	var err error
+	// fetch the target release metadata
+	var targetRelease *github.RepositoryRelease
+	var getTargetReleaseErr error
 	if opts.targetVersion == "" {
-		release, err = getLatestCorectlRelease(githubClient)
+		targetRelease, getTargetReleaseErr = getLatestCorectlRelease(githubClient)
 	} else {
-		release, err = getCorectlReleaseByTag(githubClient, opts.targetVersion)
+		targetRelease, getTargetReleaseErr = getCorectlReleaseByTag(githubClient, opts.targetVersion)
 	}
-	if err != nil {
-		logger.Error().Msg(err.Error())
-		return err
+	if getTargetReleaseErr != nil {
+		logger.Error().Msg(getTargetReleaseErr.Error())
+		return getTargetReleaseErr
 	}
 
-	asset, err := getLatestCorectlAsset(release)
-	if err != nil {
-		logger.Error().Msg(err.Error())
-		return err
+	// build CoreCtlAsset from the release object
+	asset, getTargetAssetErr := getReleaseCorectlAsset(targetRelease)
+	if getTargetAssetErr != nil {
+		logger.Error().Msg(getTargetAssetErr.Error())
+		return getTargetAssetErr
 	}
-	logger.Debug().With(zap.String("current_version", version.Version), zap.String("remote_version", asset.Version)).Msg("comparing versions")
-	if version.Version == asset.Version {
-		logger.Warn().Msgf("Already running %s release (%v)", opts.targetVersion, version.Version)
+
+	// compare current/target versions
+	targetVersion, parseTargetVersionErr := semver.NewVersion(asset.Version)
+	if parseTargetVersionErr != nil {
+		logger.Warn().Msgf("could not parse target version: %v", parseTargetVersionErr)
+		return parseTargetVersionErr
+	}
+	logger.
+		Debug().
+		With(zap.String("current_version", currentVersion.String()), zap.String("remote_version", targetVersion.String())).
+		Msg("comparing versions")
+	if currentVersion.isTargetVersionCurrent(targetVersion) {
+		logger.Warn().Msgf("Already running version %s", targetVersion.String())
 		return nil
-	} else {
-		logger.Warn().Msgf("Update available: %v", asset.Version)
+	}
+	isAhead := false
+	if currentVersion.isTargetVersionBehind(targetVersion) {
+		logger.Warn().Msgf("Target version %s is behind the current version %s", targetVersion.String(), currentVersion.String())
+	} else if currentVersion.isTargetVersionAhead(targetVersion) {
+		isAhead = true
+		logger.Warn().Msgf("Update available: %s", targetVersion.String())
 	}
 
-	out, err := glamour.Render(asset.Changelog, "dark")
-	if err == nil {
-		_, _ = opts.streams.GetOutput().Write([]byte(out))
-	} else {
-		logger.Warn().With(zap.Error(err)).Msg("could not render changelog markdown, falling back to plaintext")
-		_, _ = opts.streams.GetOutput().Write([]byte(asset.Changelog))
+	// fetch and render the changelogs for each missed release (max 10 most recent)
+	if isAhead {
+		outstandingReleases, err := listOutstandingReleasesSince(githubClient, version.Version, nil)
+		if err != nil {
+			logger.Error().Msg(err.Error())
+			return err
+		}
+		for _, release := range outstandingReleases {
+			var changelog = fmt.Sprintf("# Changelog for %s:\n%s", *release.TagName, *release.Body)
+			out, err := glamour.Render(changelog, "dark")
+			if err == nil {
+				_, _ = opts.streams.GetOutput().Write([]byte(out))
+			} else {
+				logger.Warn().With(zap.Error(err)).Msg("could not render changelog markdown, falling back to plaintext")
+				_, _ = opts.streams.GetOutput().Write([]byte(changelog))
+			}
+		}
 	}
 
 	logger.Debug().With(zap.Bool("skipConfirmation", opts.skipConfirmation)).Msg("checking params")
@@ -262,12 +353,12 @@ func update(opts UpdateOpts) error {
 		wizard.Info("--skip-confirmation is set, continuing with update")
 	} else {
 		if opts.streams.IsInteractive() {
-			confirmation, err := confirmation.GetInput(opts.streams, fmt.Sprintf("Update to %s now?", asset.Version))
+			confirmInput, err := confirmation.GetInput(opts.streams, fmt.Sprintf("Update to %s now?", asset.Version))
 			if err != nil {
 				return fmt.Errorf("could not get confirmation from user: %+v", err)
 			}
 
-			if confirmation {
+			if confirmInput {
 				wizard.Info("Update accepted")
 			} else {
 				err = fmt.Errorf("update cancelled by user")
@@ -275,12 +366,13 @@ func update(opts UpdateOpts) error {
 				return err
 			}
 		} else {
-			err = fmt.Errorf("non interactive terminal, cannot ask for confirmation")
+			err := fmt.Errorf("non interactive terminal, cannot ask for confirmation")
 			wizard.Abort(err.Error())
 			return err
 		}
 	}
 
+	var err error
 	wizard.SetTask(fmt.Sprintf("Downloading release %s", asset.Version), fmt.Sprintf("Downloaded release %s", asset.Version))
 	data, err := downloadCorectlAsset(asset)
 	if err != nil {
@@ -341,7 +433,7 @@ func update(opts UpdateOpts) error {
 	return nil
 }
 
-func getLatestCorectlAsset(release *github.RepositoryRelease) (*CoreCtlAsset, error) {
+func getReleaseCorectlAsset(release *github.RepositoryRelease) (*CoreCtlAsset, error) {
 	if release.Assets == nil {
 		return nil, errors.New("no assets found for the latest release")
 	}
@@ -366,7 +458,37 @@ func getLatestCorectlAsset(release *github.RepositoryRelease) (*CoreCtlAsset, er
 	}
 
 	return nil, errors.New("no asset found for the current architecture and OS")
+}
 
+type ListOutstandingReleasesOpts struct {
+	Pages    int
+	PageSize int
+}
+
+func listOutstandingReleasesSince(client *github.Client, version string, opts *ListOutstandingReleasesOpts) ([]*github.RepositoryRelease, error) {
+	defaultOpts := ListOutstandingReleasesOpts{Pages: 1, PageSize: 10}
+	if opts == nil {
+		opts = &defaultOpts
+	}
+
+	var releasesSince []*github.RepositoryRelease
+	page := 0
+	for page <= opts.Pages {
+		page++
+		releases, _, err := client.Repositories.ListReleases(context.Background(), "coreeng", "corectl", &github.ListOptions{Page: page, PerPage: opts.PageSize})
+		if err != nil {
+			return nil, err
+		}
+		for _, release := range releases {
+			// stop listing once we hit the current version
+			if *release.TagName == version {
+				return releasesSince, nil
+			}
+			releasesSince = append(releasesSince, release)
+		}
+	}
+
+	return releasesSince, nil
 }
 
 func getLatestCorectlRelease(client *github.Client) (*github.RepositoryRelease, error) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -12,7 +12,7 @@ var (
 type ReleaseVersion struct{ current *semver.Version }
 
 func (v ReleaseVersion) String() string {
-	return v.current.String()
+	return "v" + v.current.String()
 }
 
 func (v ReleaseVersion) IsTargetVersionAhead(target *semver.Version) bool {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,64 @@
 package version
 
+import "github.com/Masterminds/semver/v3"
+
 var (
 	Version = "dev"
 	Commit  = "unknown"
 	Date    = "unknown"
 	Arch    = "unknown"
 )
+
+type ReleaseVersion struct{ current *semver.Version }
+
+func (v ReleaseVersion) String() string {
+	return v.current.String()
+}
+
+func (v ReleaseVersion) IsTargetVersionAhead(target *semver.Version) bool {
+	return v.current.LessThan(target)
+}
+
+func (v ReleaseVersion) IsTargetVersionStringAhead(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.IsTargetVersionAhead(parsedTarget), nil
+}
+
+func (v ReleaseVersion) IsTargetVersionBehind(target *semver.Version) bool {
+	return v.current.GreaterThan(target)
+}
+
+func (v ReleaseVersion) IsTargetVersionStringBehind(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.IsTargetVersionBehind(parsedTarget), nil
+}
+
+func (v ReleaseVersion) IsTargetVersionCurrent(target *semver.Version) bool {
+	return v.current.Equal(target)
+}
+
+func (v ReleaseVersion) IsTargetVersionStringCurrent(target string) (bool, error) {
+	parsedTarget, parseTargetErr := semver.NewVersion(target)
+	if parseTargetErr != nil {
+		return false, parseTargetErr
+	}
+
+	return v.IsTargetVersionCurrent(parsedTarget), nil
+}
+
+func BuildReleaseVersion(version string) (ReleaseVersion, error) {
+	parsedVersion, parseErr := semver.NewVersion(version)
+	if parseErr != nil {
+		return ReleaseVersion{}, parseErr
+	}
+
+	return ReleaseVersion{parsedVersion}, nil
+}


### PR DESCRIPTION
* Amends `corectl update` so it will show each changelog between current version and latest (up to max of 10 versions)
* Implements `ReleaseVersion` struct with methods for semver parsing and comparison
* Adds validations around semver parsing
* If current version is invalid e.g. "dev" instead of "x.x.x" then a default "0.0.0" will be used for the sake of the comparison.
* Some tidy up of logging for this command output.
* Adds unit tests for the new list releases method.

Screenshots added to ticket:
https://github.com/coreeng/project-core-platform/issues/546