### PR TITLE
Fall back silently when no environments.yaml exists to avoid confusion

### DIFF
--- a/pkg/cmd/tenant/create/tenant_create.go
+++ b/pkg/cmd/tenant/create/tenant_create.go
@@ -148,7 +148,7 @@ func run(opt *TenantCreateOpt, cfg *config.Config) error {
 	envFilePath := filepath.Join(envsDir, "environments.yaml")
 	envs, err := listEnabledEnvironments(envFilePath)
 	if err != nil {
-		logger.Warn().Msgf("Failed to read environments file '%s': %s. Falling back to listing directories in '%s'.", envFilePath, err, envsDir)
+		logger.Info().Msgf("Failed to read environments file '%s': %s. Falling back to listing directories in '%s'.", envFilePath, err, envsDir)
 		envs, err = environment.List(envsDir)
 		if err != nil {
 			return err


### PR DESCRIPTION
`corectl` falls back to assuming all environments with a `config.yaml` are enabled if an `environments.yaml` doesn't exist.

Logging this should be info level (so log file only) and not warn (so also on console) to avoid confusion, as the error message looks critical.