### PR TITLE
Correct actions path filter for single repo apps

### DIFF
--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -104,7 +104,7 @@ func (svc *Service) handleSingleRepo(op CreateOp, localRepo *git.LocalRepository
 	additionalArgs := []template.Argument{
 		{
 			Name:  "working_directory",
-			Value: "./",
+			Value: "",
 		},
 		{
 			Name:  "version_prefix",

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -273,7 +273,7 @@ var _ = Describe("Create new application", func() {
 				},
 				template.Argument{
 					Name:  "working_directory",
-					Value: "./",
+					Value: "",
 				},
 				template.Argument{
 					Name:  "version_prefix",
@@ -288,13 +288,13 @@ var _ = Describe("Create new application", func() {
 			content := readFileContent(rootWorkflowsPath, "fast-feedback.yaml")
 			Expect(content).To(ContainSubstring("tenant: " + defaultTenant.Name))
 			Expect(content).To(ContainSubstring("name: " + newAppName))
-			Expect(content).To(ContainSubstring("working_directory: ./"))
+			Expect(content).To(ContainSubstring("working_directory: "))
 			Expect(content).To(ContainSubstring("version_prefix: v"))
 
 			content = readFileContent(rootWorkflowsPath, "extended-test.yaml")
 			Expect(content).To(ContainSubstring("tenant: " + defaultTenant.Name))
 			Expect(content).To(ContainSubstring("name: " + newAppName))
-			Expect(content).To(ContainSubstring("working_directory: ./"))
+			Expect(content).To(ContainSubstring("working_directory: "))
 			Expect(content).To(ContainSubstring("version_prefix: v"))
 		})
 


### PR DESCRIPTION
This caused the path filter to be set to `.//**` which ignores the top level dir. Correct would be just '**' or omitting path entirely.

This sets the path to '' which causes the template to skip path filter and working-dir directly.
