### PR TITLE
Fix git repository detection from subdirectories

### DIFF
--- a/pkg/git/local_repository.go
+++ b/pkg/git/local_repository.go
@@ -120,7 +120,9 @@ func getOrgAndNameFromUrl(url string) (string, string, error) {
 }
 
 func GetLocalRepoOrgAndName(localpath string) (string, string, error) {
-	repo, err := git.PlainOpen(localpath)
+	repo, err := git.PlainOpenWithOptions(localpath, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	if err != nil {
 		return "", "", err
 	}
@@ -157,7 +159,9 @@ func OpenLocalRepository(path string, dryRun bool) (*LocalRepository, error) {
 		zap.Bool("dry_run", dryRun)).
 		Msg("git: opening repository")
 	localRepository := &LocalRepository{DryRun: dryRun}
-	repository, err := git.PlainOpen(path)
+	repository, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	localRepository.repo = repository
 	if err != nil {
 		return localRepository, fmt.Errorf("repository on path %s not found: %w", path, err)

--- a/tests/integration/p2p/export.go
+++ b/tests/integration/p2p/export.go
@@ -63,7 +63,9 @@ var _ = Describe("export", Ordered, func() {
 	Context("export", func() {
 
 		var commitHash = func(repoPath string) string {
-			r, err := gogit.PlainOpen(repoPath)
+			r, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{
+				DetectDotGit: true,
+			})
 			Expect(err).NotTo(HaveOccurred())
 			ref, err := r.Head()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

The go-git library's `PlainOpen()` function only works when the path points directly to a repository root, unlike native git which searches up the directory tree.

This caused commands like `corectl p2p export` to fail when run from subdirectories within a git repository.

## Changes

Changed three instances to use `PlainOpenWithOptions` with `DetectDotGit` enabled, which walks parent directories to find the .git directory:

- `OpenLocalRepository()` in pkg/git/local_repository.go
- `GetLocalRepoOrgAndName()` in pkg/git/local_repository.go
- `commitHash` test helper in tests/integration/p2p/export.go

## Test Plan

- [x] Verify `corectl p2p export` works when run from repository root
- [x] Verify `corectl p2p export` works when run from subdirectories
- [x] Verify tests pass