### PR TITLE
Add multi-shell support to `p2p export` command

### DIFF
--- a/pkg/cmd/p2p/export/export_test.go
+++ b/pkg/cmd/p2p/export/export_test.go
@@ -33,6 +33,7 @@ func TestRunExportPrintsEnvVarsToStdOut(t *testing.T) {
 		tenant:          testdata.DefaultTenant(),
 		environmentName: testdata.DevEnvironment(),
 		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		shell:           "bash",
 		streams:         userio.NewIOStreams(os.Stdin, &output, &stderr),
 	}, cfg)
 
@@ -50,6 +51,7 @@ func TestRunExportNonExistingAppRepo(t *testing.T) {
 		tenant:          testdata.DefaultTenant(),
 		environmentName: testdata.DevEnvironment(),
 		repoPath:        appRepoPath,
+		shell:           "bash",
 		streams:         streams,
 	}, cfg)
 
@@ -66,6 +68,7 @@ func TestRunExportNonExistingTenant(t *testing.T) {
 		tenant:          tenantName,
 		environmentName: testdata.DevEnvironment(),
 		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		shell:           "bash",
 		streams:         streams,
 	}, cfg)
 
@@ -83,6 +86,7 @@ func TestFailureWithRootTenant(t *testing.T) {
 		tenant:          tenantName,
 		environmentName: testdata.DevEnvironment(),
 		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		shell:           "bash",
 		streams:         streams,
 	}, cfg)
 
@@ -99,6 +103,7 @@ func TestRunExportNonExistingEnvironment(t *testing.T) {
 		tenant:          testdata.DefaultTenant(),
 		environmentName: envName,
 		repoPath:        testLocalRepo(t, testdata.CPlatformEnvsPath()).Path(),
+		shell:           "bash",
 		streams:         streams,
 	}, cfg)
 

--- a/pkg/p2p/env_variables.go
+++ b/pkg/p2p/env_variables.go
@@ -3,6 +3,8 @@ package p2p
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/coreeng/core-platform/pkg/environment"
 	coretnt "github.com/coreeng/core-platform/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/git"
@@ -17,6 +19,33 @@ const (
 	TenantName = "TENANT_NAME"
 )
 
+// ShellType represents the type of shell for environment variable export
+type ShellType string
+
+const (
+	ShellBash       ShellType = "bash"
+	ShellZsh        ShellType = "zsh"
+	ShellFish       ShellType = "fish"
+	ShellPowershell ShellType = "powershell"
+	ShellCmd        ShellType = "cmd"
+)
+
+// SupportedShells returns a list of all supported shell types
+func SupportedShells() []ShellType {
+	return []ShellType{ShellBash, ShellZsh, ShellFish, ShellPowershell, ShellCmd}
+}
+
+// IsValidShell checks if the given shell type is supported
+func IsValidShell(shell string) bool {
+	shellType := ShellType(strings.ToLower(shell))
+	for _, s := range SupportedShells() {
+		if s == shellType {
+			return true
+		}
+	}
+	return false
+}
+
 type EnvVarContext struct {
 	Tenant      *coretnt.Tenant
 	Environment *environment.Environment
@@ -24,20 +53,86 @@ type EnvVarContext struct {
 }
 type EnvVars map[string]string
 
-func (p2pEnv *EnvVars) AsExportCmd() (string, error) {
-	s, err := p2pEnv.asKeyValString("export")
-	if err != nil {
-		return "", err
+// AsExportCmd converts environment variables to shell-specific export statements
+func (p2pEnv *EnvVars) AsExportCmd(shell ShellType) (string, error) {
+	switch shell {
+	case ShellBash, ShellZsh:
+		return p2pEnv.formatBashZsh()
+	case ShellFish:
+		return p2pEnv.formatFish()
+	case ShellPowershell:
+		return p2pEnv.formatPowershell()
+	case ShellCmd:
+		return p2pEnv.formatCmd()
+	default:
+		return "", fmt.Errorf("unsupported shell type: %s", shell)
 	}
-	return s, nil
 }
 
-func (p2pEnv *EnvVars) asKeyValString(keyPrefix string) (string, error) {
+// formatBashZsh formats variables for bash/zsh using double quotes
+func (p2pEnv *EnvVars) formatBashZsh() (string, error) {
 	b := new(bytes.Buffer)
 	for key, value := range *p2pEnv {
-		_, err := fmt.Fprintf(b, "%s %s=\"%s\"\n", keyPrefix, key, value)
+		// Always use double quotes and escape special characters within them
+		// In double quotes, we need to escape: $ ` " \ and newline
+		escapedValue := value
+		escapedValue = strings.ReplaceAll(escapedValue, "\\", "\\\\") // Must escape backslash first
+		escapedValue = strings.ReplaceAll(escapedValue, "\"", "\\\"") // Escape double quotes
+		escapedValue = strings.ReplaceAll(escapedValue, "$", "\\$")   // Escape dollar signs
+		escapedValue = strings.ReplaceAll(escapedValue, "`", "\\`")   // Escape backticks
+		escapedValue = strings.ReplaceAll(escapedValue, "\n", "\\n")  // Escape newlines
+
+		_, err := fmt.Fprintf(b, "export %s=\"%s\"\n", key, escapedValue)
 		if err != nil {
-			return "", fmt.Errorf("faild to convert vars map %v to string", p2pEnv)
+			return "", fmt.Errorf("failed to format bash/zsh export for %s: %w", key, err)
+		}
+	}
+	return b.String(), nil
+}
+
+// formatFish formats variables for fish shell
+func (p2pEnv *EnvVars) formatFish() (string, error) {
+	b := new(bytes.Buffer)
+	for key, value := range *p2pEnv {
+		// Fish uses single quotes for literal strings, escape single quotes by ending quote, adding escaped quote, and starting new quote
+		escapedValue := strings.ReplaceAll(value, "'", "'\\''")
+		_, err := fmt.Fprintf(b, "set -gx %s '%s'\n", key, escapedValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to format fish export for %s: %w", key, err)
+		}
+	}
+	return b.String(), nil
+}
+
+// formatPowershell formats variables for PowerShell
+func (p2pEnv *EnvVars) formatPowershell() (string, error) {
+	b := new(bytes.Buffer)
+	for key, value := range *p2pEnv {
+		// PowerShell uses single quotes for literal strings, escape single quotes with double single quotes
+		escapedValue := strings.ReplaceAll(value, "'", "''")
+		_, err := fmt.Fprintf(b, "$Env:%s = '%s'\n", key, escapedValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to format powershell export for %s: %w", key, err)
+		}
+	}
+	return b.String(), nil
+}
+
+// formatCmd formats variables for Windows cmd.exe
+func (p2pEnv *EnvVars) formatCmd() (string, error) {
+	b := new(bytes.Buffer)
+	for key, value := range *p2pEnv {
+		// cmd.exe doesn't handle quotes well in set commands, and special chars need escaping with ^
+		// We'll keep it simple and not quote unless necessary
+		escapedValue := value
+		// Escape special characters for cmd (note: must escape ^ first to avoid double-escaping)
+		specialChars := []string{"^", "&", "|", "<", ">", "%"}
+		for _, char := range specialChars {
+			escapedValue = strings.ReplaceAll(escapedValue, char, "^"+char)
+		}
+		_, err := fmt.Fprintf(b, "set %s=%s\n", key, escapedValue)
+		if err != nil {
+			return "", fmt.Errorf("failed to format cmd export for %s: %w", key, err)
 		}
 	}
 	return b.String(), nil

--- a/pkg/p2p/env_variables_test.go
+++ b/pkg/p2p/env_variables_test.go
@@ -41,13 +41,14 @@ func TestCreateEnvVarsReturnsVarsAsExportCmd(t *testing.T) {
 	vars, err := NewP2pEnvVariables(&EnvVarContext{Tenant: tenant, Environment: env, AppRepo: testRepo})
 
 	assert.NoError(t, err)
-	assert.Contains(t, asExportCmd(t, vars),
-		envVarFormat(t, BaseDomain, env.GetDefaultIngressDomain().Domain),
-		envVarFormat(t, Registry, toRegistry(t, env.Platform.(*environment.GCPVendor), tenant.Name)),
-		envVarFormat(t, Version, commitHash(t, testRepo)),
-		envVarFormat(t, RepoPath, testRepo.Path()),
-		envVarFormat(t, Region, env.Platform.(*environment.GCPVendor).Region),
-		envVarFormat(t, TenantName, tenant.Name))
+	exportCmd := asExportCmd(t, vars)
+	// Check that all variables are present in the export command
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", BaseDomain))
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", Registry))
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", Version))
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", RepoPath))
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", Region))
+	assert.Contains(t, exportCmd, fmt.Sprintf("export %s=", TenantName))
 }
 
 func TestCreateEnvVarsUnsupportedPlatform(t *testing.T) {
@@ -90,10 +91,6 @@ func testLocalRepo(t *testing.T) *git.LocalRepository {
 	return repo
 }
 
-var envVarFormat = func(_ *testing.T, k, v string) string {
-	return fmt.Sprintf("export %s=\"%s\"", k, v)
-}
-
 var commitHash = func(t *testing.T, repo *git.LocalRepository) string {
 	hash, err := repo.HeadShortCommitHash()
 	assert.NoError(t, err)
@@ -101,11 +98,253 @@ var commitHash = func(t *testing.T, repo *git.LocalRepository) string {
 }
 
 var asExportCmd = func(t *testing.T, vars *EnvVars) string {
-	cmd, err := vars.AsExportCmd()
+	cmd, err := vars.AsExportCmd(ShellBash)
 	assert.NoError(t, err)
 	return cmd
 }
 
 var toRegistry = func(_ *testing.T, vendor *environment.GCPVendor, tenantName string) string {
 	return fmt.Sprintf("%s-docker.pkg.dev/%s/tenant/%s", vendor.Region, vendor.ProjectId, tenantName)
+}
+
+// TestShellFormats tests export formatting for all supported shell types
+func TestShellFormats(t *testing.T) {
+	testCases := []struct {
+		name     string
+		shell    ShellType
+		vars     EnvVars
+		expected map[string]string // key -> expected line in output
+	}{
+		{
+			name:  "bash basic",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY1": "value1",
+				"KEY2": "value2",
+			},
+			expected: map[string]string{
+				"KEY1": "export KEY1=\"value1\"\n",
+				"KEY2": "export KEY2=\"value2\"\n",
+			},
+		},
+		{
+			name:  "bash with spaces",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY": "value with spaces",
+			},
+			expected: map[string]string{
+				"KEY": "export KEY=\"value with spaces\"\n",
+			},
+		},
+		{
+			name:  "bash with special chars",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY": "value$with&special|chars",
+			},
+			expected: map[string]string{
+				// Dollar signs must be escaped in double quotes
+				"KEY": "export KEY=\"value\\$with&special|chars\"\n",
+			},
+		},
+		{
+			name:  "bash with quotes",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY": "value'with\"quotes",
+			},
+			expected: map[string]string{
+				// Double quotes must be escaped in double quotes, single quotes don't need escaping
+				"KEY": "export KEY=\"value'with\\\"quotes\"\n",
+			},
+		},
+		{
+			name:  "bash with backslash",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY": "value\\with\\backslashes",
+			},
+			expected: map[string]string{
+				// Backslashes must be escaped
+				"KEY": "export KEY=\"value\\\\with\\\\backslashes\"\n",
+			},
+		},
+		{
+			name:  "bash with backtick",
+			shell: ShellBash,
+			vars: EnvVars{
+				"KEY": "value`with`backticks",
+			},
+			expected: map[string]string{
+				// Backticks must be escaped
+				"KEY": "export KEY=\"value\\`with\\`backticks\"\n",
+			},
+		},
+		{
+			name:  "zsh basic",
+			shell: ShellZsh,
+			vars: EnvVars{
+				"KEY": "value",
+			},
+			expected: map[string]string{
+				"KEY": "export KEY=\"value\"\n",
+			},
+		},
+		{
+			name:  "fish basic",
+			shell: ShellFish,
+			vars: EnvVars{
+				"KEY1": "value1",
+				"KEY2": "value2",
+			},
+			expected: map[string]string{
+				"KEY1": "set -gx KEY1 'value1'\n",
+				"KEY2": "set -gx KEY2 'value2'\n",
+			},
+		},
+		{
+			name:  "fish with spaces",
+			shell: ShellFish,
+			vars: EnvVars{
+				"KEY": "value with spaces",
+			},
+			expected: map[string]string{
+				"KEY": "set -gx KEY 'value with spaces'\n",
+			},
+		},
+		{
+			name:  "fish with single quotes",
+			shell: ShellFish,
+			vars: EnvVars{
+				"KEY": "value'with'quotes",
+			},
+			expected: map[string]string{
+				"KEY": "set -gx KEY 'value'\\''with'\\''quotes'\n",
+			},
+		},
+		{
+			name:  "powershell basic",
+			shell: ShellPowershell,
+			vars: EnvVars{
+				"KEY1": "value1",
+				"KEY2": "value2",
+			},
+			expected: map[string]string{
+				"KEY1": "$Env:KEY1 = 'value1'\n",
+				"KEY2": "$Env:KEY2 = 'value2'\n",
+			},
+		},
+		{
+			name:  "powershell with spaces",
+			shell: ShellPowershell,
+			vars: EnvVars{
+				"KEY": "value with spaces",
+			},
+			expected: map[string]string{
+				"KEY": "$Env:KEY = 'value with spaces'\n",
+			},
+		},
+		{
+			name:  "powershell with single quotes",
+			shell: ShellPowershell,
+			vars: EnvVars{
+				"KEY": "value'with'quotes",
+			},
+			expected: map[string]string{
+				"KEY": "$Env:KEY = 'value''with''quotes'\n",
+			},
+		},
+		{
+			name:  "cmd basic",
+			shell: ShellCmd,
+			vars: EnvVars{
+				"KEY1": "value1",
+				"KEY2": "value2",
+			},
+			expected: map[string]string{
+				"KEY1": "set KEY1=value1\n",
+				"KEY2": "set KEY2=value2\n",
+			},
+		},
+		{
+			name:  "cmd with spaces",
+			shell: ShellCmd,
+			vars: EnvVars{
+				"KEY": "value with spaces",
+			},
+			expected: map[string]string{
+				"KEY": "set KEY=value with spaces\n",
+			},
+		},
+		{
+			name:  "cmd with special chars",
+			shell: ShellCmd,
+			vars: EnvVars{
+				"KEY": "value&with|special>chars",
+			},
+			expected: map[string]string{
+				"KEY": "set KEY=value^&with^|special^>chars\n",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := tc.vars.AsExportCmd(tc.shell)
+			assert.NoError(t, err)
+
+			for key, expectedLine := range tc.expected {
+				assert.Contains(t, output, expectedLine,
+					"Expected to find '%s' in output for %s", expectedLine, key)
+			}
+		})
+	}
+}
+
+// TestShellTypeValidation tests the shell type validation functions
+func TestShellTypeValidation(t *testing.T) {
+	testCases := []struct {
+		name     string
+		shell    string
+		isValid  bool
+	}{
+		{"bash lowercase", "bash", true},
+		{"bash uppercase", "BASH", true},
+		{"bash mixed case", "BaSh", true},
+		{"zsh", "zsh", true},
+		{"fish", "fish", true},
+		{"powershell", "powershell", true},
+		{"pwsh alias", "pwsh", false}, // not supported as alias
+		{"cmd", "cmd", true},
+		{"invalid shell", "invalid", false},
+		{"empty string", "", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsValidShell(tc.shell)
+			assert.Equal(t, tc.isValid, result,
+				"IsValidShell(%s) should return %v", tc.shell, tc.isValid)
+		})
+	}
+}
+
+// TestSupportedShells tests that all expected shells are in the supported list
+func TestSupportedShells(t *testing.T) {
+	shells := SupportedShells()
+	assert.Len(t, shells, 5, "Should have exactly 5 supported shells")
+	assert.Contains(t, shells, ShellBash)
+	assert.Contains(t, shells, ShellZsh)
+	assert.Contains(t, shells, ShellFish)
+	assert.Contains(t, shells, ShellPowershell)
+	assert.Contains(t, shells, ShellCmd)
+}
+
+// TestUnsupportedShellType tests error handling for unsupported shell types
+func TestUnsupportedShellType(t *testing.T) {
+	vars := EnvVars{"KEY": "value"}
+	_, err := vars.AsExportCmd(ShellType("unsupported"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported shell type")
 }


### PR DESCRIPTION
## Summary

Added `--shell` flag (shorthand `-s`) to the `corectl p2p export` command with support for 5 modern shells:

- **bash** (default) - `export KEY="value"`
- **zsh** - `export KEY="value"`
- **fish** - `set -gx KEY 'value'`
- **powershell** - `$Env:KEY = 'value'`
- **cmd** - `set KEY=value`

## Changes

- Updated `pkg/cmd/p2p/export/export.go` to add `--shell` flag
- Enhanced `pkg/p2p/env_variables.go` with shell-specific formatting functions
- Added comprehensive tests in `pkg/p2p/env_variables_test.go`
- Updated integration tests in `tests/integration/p2p/export.go`

## Test Plan

- [x] Verify default behavior (bash format) remains unchanged
- [x] Test `--shell bash` output format
- [x] Test `--shell zsh` output format
- [x] Test `--shell fish` output format
- [x] Test `--shell powershell` output format
- [x] Test `--shell cmd` output format
- [x] Verify all automated tests pass