### PR TITLE
Improve multi-region support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.50.2
+	github.com/coreeng/core-platform/pkg v0.51.0
 	github.com/go-git/go-billy/v5 v5.7.0
 	github.com/go-git/go-git/v5 v5.16.5
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/coreeng/core-platform/pkg v0.50.2 h1:mHh7haLMs5kkwYZlYav8hjpME4jVuAmzXtP7lNqNdv0=
-github.com/coreeng/core-platform/pkg v0.50.2/go.mod h1:l+xkENE1QeJ0EwAR7KvmDxjc5RMNo/KHCtAePlOJ0Tw=
+github.com/coreeng/core-platform/pkg v0.51.0 h1:Xi6FgucyrKnlDGAynq1MbV+pg51gp5EO+eWR37i4wZE=
+github.com/coreeng/core-platform/pkg v0.51.0/go.mod h1:l+xkENE1QeJ0EwAR7KvmDxjc5RMNo/KHCtAePlOJ0Tw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -203,7 +203,7 @@ var _ = Describe("Create new application", func() {
 			})))
 		})
 		It("configured environments with variables", func() {
-			Expect(createEnvVarCapture.Requests).To(HaveLen(10))
+			Expect(createEnvVarCapture.Requests).To(HaveLen(12))
 			for _, env := range []environment.Environment{devEnv, prodEnv} {
 				var envRelatedRequests []httpmock.ActionEnvVariableRequest
 				for _, r := range createEnvVarCapture.Requests {
@@ -232,6 +232,10 @@ var _ = Describe("Create new application", func() {
 					Satisfy(func(r httpmock.ActionEnvVariableRequest) bool {
 						return r.Var.Name == "PROJECT_NUMBER" &&
 							r.Var.Value == gcpVendor.ProjectNumber
+					}),
+					Satisfy(func(r httpmock.ActionEnvVariableRequest) bool {
+						return r.Var.Name == "REGION" &&
+							r.Var.Value == gcpVendor.Region
 					}),
 				))
 				Expect(envRelatedRequests).To(HaveEach(Satisfy(func(r httpmock.ActionEnvVariableRequest) bool {

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -154,7 +154,7 @@ var _ = Describe("application", Ordered, func() {
 					&github.ListOptions{},
 				)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(envVars.TotalCount).To(Equal(5))
+				Expect(envVars.TotalCount).To(Equal(6))
 				gcpVendor := env.Platform.(*environment.GCPVendor)
 				Expect(envVars.Variables).To(ConsistOf(
 					Satisfy(func(v *github.ActionsVariable) bool {
@@ -176,6 +176,10 @@ var _ = Describe("application", Ordered, func() {
 					Satisfy(func(v *github.ActionsVariable) bool {
 						return v.Name == "PROJECT_NUMBER" &&
 							v.Value == gcpVendor.ProjectNumber
+					}),
+					Satisfy(func(v *github.ActionsVariable) bool {
+						return v.Name == "REGION" &&
+							v.Value == gcpVendor.Region
 					}),
 				))
 			}
@@ -448,7 +452,7 @@ var _ = Describe("application", Ordered, func() {
 					&github.ListOptions{},
 				)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(envVars.TotalCount).To(Equal(5))
+				Expect(envVars.TotalCount).To(Equal(6))
 				gcpVendor := env.Platform.(*environment.GCPVendor)
 				Expect(envVars.Variables).To(ConsistOf(
 					Satisfy(func(v *github.ActionsVariable) bool {
@@ -470,6 +474,10 @@ var _ = Describe("application", Ordered, func() {
 					Satisfy(func(v *github.ActionsVariable) bool {
 						return v.Name == "PROJECT_NUMBER" &&
 							v.Value == gcpVendor.ProjectNumber
+					}),
+					Satisfy(func(v *github.ActionsVariable) bool {
+						return v.Name == "REGION" &&
+							v.Value == gcpVendor.Region
 					}),
 				))
 			}


### PR DESCRIPTION
## Summary

- Bump `github.com/coreeng/core-platform/pkg` dependency from `v0.50.2` → `v0.51.0`, which adds a `REGION` GitHub Actions environment variable alongside the existing `PROJECT_ID`, `PROJECT_NUMBER`, `DPLATFORM`, `BASE_DOMAIN`, and `INTERNAL_SERVICES_DOMAIN` variables.
- Update unit test (`pkg/application/create_test.go`): `HaveLen(10)` → `HaveLen(12)` and add `REGION` assertion to the `ConsistOf` matcher.
- Update integration tests (`tests/integration/application/application.go`): `TotalCount` → `6` and add `REGION` assertion to both "correctly configured environments for the new app repo" test blocks.

## Motivation

Part of multi-region P2P support. Storing `REGION` as a per-environment GitHub Actions variable (consistent with `PROJECT_ID`/`PROJECT_NUMBER`) allows P2P workflows to resolve the correct region per environment via `vars.REGION`, enabling deployments across environments in different regions within the same stage.