### PR TITLE
Fix monorepo app tenant onboarding

### DIFF
--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -272,10 +272,6 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 
 	var nextStepsMessage string
 	if createdAppResult.MonorepoMode {
-		// In monorepo mode we normally don't create a tenant configuration PR.
-		// However, if the selected tenant is a team, corectl creates an app tenant for the app.
-		// That app tenant must be persisted in the platform repo so that platform automation
-		// (e.g. GCP identity/WIF) is provisioned for the app tenant.
 		if teamTenant != nil {
 			logger.Warn().Msgf("Creating PR with new app tenant '%s' for team %s in platform repo (monorepo mode)",
 				appTenant.Name, teamTenant.Name)

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -272,6 +272,20 @@ func run(opts *AppCreateOpt, cfg *config.Config) error {
 
 	var nextStepsMessage string
 	if createdAppResult.MonorepoMode {
+		// In monorepo mode we normally don't create a tenant configuration PR.
+		// However, if the selected tenant is a team, corectl creates an app tenant for the app.
+		// That app tenant must be persisted in the platform repo so that platform automation
+		// (e.g. GCP identity/WIF) is provisioned for the app tenant.
+		if teamTenant != nil {
+			logger.Warn().Msgf("Creating PR with new app tenant '%s' for team %s in platform repo (monorepo mode)",
+				appTenant.Name, teamTenant.Name)
+			tenantUpdateResult, err := createPRWithNewTenantAndRepo(opts, cfg, githubClient, appTenant, teamTenant, createdAppResult)
+			if err != nil {
+				return err
+			}
+			logger.Warn().Msgf("Created PR with new app tenant: %s", tenantUpdateResult.PRUrl)
+		}
+
 		nextStepsMessage = fmt.Sprintf(
 			nextStepsMessageTemplateMonoRepo,
 			createdAppResult.PRUrl,

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -367,12 +367,12 @@ var _ = Describe("application", Ordered, func() {
 			// Use existing "parent" team tenant
 			teamTenantName = "parent"
 
-			monorepoName = "test-monorepo-team-" + testRunId
+			monorepoName = "test-monorepo-team-" + strings.ToLower(testRunId)
 			monorepoDir = filepath.Join(homeDir, monorepoName)
 			createMonorepoRepositoryRemoteAndLocal(githubClient, ctx, cfg, monorepoName, monorepoDir)
 
 			// Create a new app within the monorepo under a team tenant.
-			newAppName = "new-monorepo-team-app-" + testRunId
+			newAppName = "new-monorepo-team-app-" + strings.ToLower(testRunId)
 			appDir = filepath.Join(monorepoDir, newAppName)
 			_, err := corectl.Run(
 				"application", "create", newAppName, appDir,

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -354,6 +354,98 @@ var _ = Describe("application", Ordered, func() {
 		}, SpecTimeout(time.Minute))
 	})
 
+	Context("create in monorepo mode with team tenant", Ordered, func() {
+		var (
+			teamTenantName string
+			monorepoName   string
+			monorepoDir    string
+			newAppName     string
+			appDir         string
+		)
+
+		BeforeAll(func(ctx SpecContext) {
+			// Use existing "parent" team tenant
+			teamTenantName = "parent"
+
+			monorepoName = "test-monorepo-team-" + testRunId
+			monorepoDir = filepath.Join(homeDir, monorepoName)
+			createMonorepoRepositoryRemoteAndLocal(githubClient, ctx, cfg, monorepoName, monorepoDir)
+
+			// Create a new app within the monorepo under a team tenant.
+			newAppName = "new-monorepo-team-app-" + testRunId
+			appDir = filepath.Join(monorepoDir, newAppName)
+			_, err := corectl.Run(
+				"application", "create", newAppName, appDir,
+				"-t", testdata.BlankTemplate(),
+				"--tenant", teamTenantName,
+				"--non-interactive")
+			Expect(err).ToNot(HaveOccurred())
+		}, NodeTimeout(3*time.Minute))
+
+		AfterAll(func(ctx SpecContext) {
+			// Clean up the monorepo repository
+			err := git.RetryGitHubOperation(
+				func() error {
+					_, err := githubClient.Repositories.Delete(
+						ctx,
+						cfg.GitHub.Organization.Value,
+						monorepoName,
+					)
+					return err
+				},
+				git.DefaultMaxRetries,
+				git.DefaultBaseDelay,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}, NodeTimeout(time.Minute))
+
+		It("created a PR for the new app in the monorepo", func(ctx SpecContext) {
+			prList, _, err := githubClient.PullRequests.List(
+				ctx,
+				cfg.GitHub.Organization.Value,
+				monorepoName,
+				&github.PullRequestListOptions{
+					Head: cfg.GitHub.Organization.Value + ":add-" + newAppName,
+					Base: git.MainBranch,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prList).To(HaveLen(1))
+			Expect(prList[0]).NotTo(BeNil())
+		}, SpecTimeout(time.Minute))
+
+		It("created a PR for new app tenant configuration", func(ctx SpecContext) {
+			prList, _, err := githubClient.PullRequests.List(
+				ctx,
+				cfgDetails.CPlatformRepoName.Organization(),
+				cfgDetails.CPlatformRepoName.Name(),
+				&github.PullRequestListOptions{
+					Head: cfgDetails.CPlatformRepoName.Organization() + ":new-app-tenant-" + newAppName,
+					Base: git.MainBranch,
+				},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prList).To(HaveLen(1))
+			Expect(prList[0]).NotTo(BeNil())
+			pr := prList[0]
+			Expect(pr.GetTitle()).To(Equal("New app tenant: " + newAppName))
+			Expect(pr.GetState()).To(Equal("open"))
+
+			prFiles, _, err := githubClient.PullRequests.ListFiles(
+				ctx,
+				cfgDetails.CPlatformRepoName.Organization(),
+				cfgDetails.CPlatformRepoName.Name(),
+				pr.GetNumber(),
+				&github.ListOptions{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(prFiles).To(HaveLen(1))
+			prFile := prFiles[0]
+			Expect(prFile.GetStatus()).To(Equal("added"))
+			Expect(prFile.GetFilename()).To(Equal("tenants/tenants/" + teamTenantName + "/" + newAppName + ".app.yaml"))
+		}, SpecTimeout(2*time.Minute))
+	})
+
 	Context("create with team tenant", Ordered, func() {
 		var (
 			teamTenantName string


### PR DESCRIPTION
## Why
Monorepo app creation under a team tenant creates an in-memory app tenant, but corectl did not persist that tenant to the platform repo. That leaves the app tenant unprovisioned (e.g. missing WIF/provider) and P2P workflows fail when they use the app tenant name.

## What changed
- When `application create` runs in monorepo mode and `--tenant` is a team, corectl now opens a PR to the platform repo to add the new app tenant under the team.
- Added an integration test covering monorepo mode with a team tenant.