### PR TITLE
Stop setting TENANT_NAME as repo variable

### DIFF
--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -438,13 +438,43 @@ func (svc *Service) synchronizeRepository(op CreateOp, repoFullId git.GithubRepo
 func (svc *Service) synchronizeRepositoryWithRetry(op CreateOp, repoFullId git.GithubRepoFullId) error {
 	return git.RetryGitHubOperation(
 		func() error {
-			return p2p.SynchronizeRepository(&p2p.SynchronizeOp{
-				RepositoryId:     &repoFullId,
-				Tenant:           op.Tenant,
-				FastFeedbackEnvs: op.FastFeedbackEnvs,
-				ExtendedTestEnvs: op.ExtendedTestEnvs,
-				ProdEnvs:         op.ProdEnvs,
-			}, svc.GithubClient)
+			if err := p2p.CreateStageRepositoryConfig(
+				svc.GithubClient,
+				repoFullId,
+				p2p.FastFeedbackVar,
+				p2p.NewStageRepositoryConfig(op.FastFeedbackEnvs),
+			); err != nil {
+				return err
+			}
+			if err := p2p.CreateStageRepositoryConfig(
+				svc.GithubClient,
+				repoFullId,
+				p2p.ExtendedTestVar,
+				p2p.NewStageRepositoryConfig(op.ExtendedTestEnvs),
+			); err != nil {
+				return err
+			}
+			if err := p2p.CreateStageRepositoryConfig(
+				svc.GithubClient,
+				repoFullId,
+				p2p.ProdVar,
+				p2p.NewStageRepositoryConfig(op.ProdEnvs),
+			); err != nil {
+				return err
+			}
+
+			var createdEnvs []string
+			for _, env := range slices.Concat(op.FastFeedbackEnvs, op.ExtendedTestEnvs, op.ProdEnvs) {
+				if slices.Contains(createdEnvs, env.Environment) {
+					continue
+				}
+				createdEnvs = append(createdEnvs, env.Environment)
+				envCopy := env
+				if err := p2p.CreateUpdateEnvironmentForRepository(svc.GithubClient, repoFullId, &envCopy); err != nil {
+					return err
+				}
+			}
+			return nil
 		},
 		git.DefaultMaxRetries,
 		git.DefaultBaseDelay,

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -167,10 +167,6 @@ var _ = Describe("Create new application", func() {
 		It("created variables in new repo", func() {
 			Expect(createRepoVarCapture.Requests).To(ConsistOf(
 				Satisfy(func(v httpmock.ActionVariableRequest) bool {
-					return v.Var.Name == "TENANT_NAME" &&
-						v.Var.Value == defaultTenant.Name
-				}),
-				Satisfy(func(v httpmock.ActionVariableRequest) bool {
 					return v.Var.Name == "FAST_FEEDBACK" &&
 						v.Var.Value == fmt.Sprintf("{\"include\":[{\"deploy_env\":\"%s\"}]}", devEnv.Environment)
 				}),

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -124,12 +124,8 @@ var _ = Describe("application", Ordered, func() {
 				&github.ListOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(repoVars.TotalCount).To(Equal(4))
+			Expect(repoVars.TotalCount).To(Equal(3))
 			Expect(repoVars.Variables).To(ConsistOf(
-				Satisfy(func(v *github.ActionsVariable) bool {
-					return v.Name == "TENANT_NAME" &&
-						v.Value == testconfig.Cfg.Tenant
-				}),
 				Satisfy(func(v *github.ActionsVariable) bool {
 					return v.Name == "FAST_FEEDBACK" &&
 						v.Value == fmt.Sprintf("{\"include\":[{\"deploy_env\":\"%s\"}]}", devEnv.Environment)
@@ -422,12 +418,8 @@ var _ = Describe("application", Ordered, func() {
 				&github.ListOptions{},
 			)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(repoVars.TotalCount).To(Equal(4))
+			Expect(repoVars.TotalCount).To(Equal(3))
 			Expect(repoVars.Variables).To(ConsistOf(
-				Satisfy(func(v *github.ActionsVariable) bool {
-					return v.Name == "TENANT_NAME" &&
-						v.Value == newAppName // App tenant has same name as app
-				}),
 				Satisfy(func(v *github.ActionsVariable) bool {
 					return v.Name == "FAST_FEEDBACK" &&
 						v.Value == fmt.Sprintf("{\"include\":[{\"deploy_env\":\"%s\"}]}", devEnv.Environment)


### PR DESCRIPTION
## Why
With per-app tenants (and monorepos), `TENANT_NAME` should be provided explicitly by workflows (as the reusable workflow input `tenant-name`). A single repo-level `TENANT_NAME` variable is ambiguous in monorepos and can cause workflows to target a non-existent WIF provider.

## What changed
- Corectl no longer creates/updates the repository-level `TENANT_NAME` Actions variable during app creation.
- Corectl still sets the stage matrix repo variables (`FAST_FEEDBACK`, `EXTENDED_TEST`, `PROD`) and environment-scoped variables.
- Updated tests to reflect the new repo variable set.

## Testing
- Unit tests pass locally (integration tests require `TEST_CORECTL_BINARY`).