### PR TITLE
PT-261 Update core-platform pkg to v0.58.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.57.1
+	github.com/coreeng/core-platform/pkg v0.58.0
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/coreeng/core-platform/pkg v0.57.1 h1:o/VQlzmxcKyX9q39lMKzlc35rhX1skh2dvCflrIlzkM=
 github.com/coreeng/core-platform/pkg v0.57.1/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
+github.com/coreeng/core-platform/pkg v0.58.0 h1:3v4Ur8GMqIp5403ZXSfp0o9eph1ewdP6lCp+NWjjIEk=
+github.com/coreeng/core-platform/pkg v0.58.0/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -14,9 +14,9 @@ type TableEnv struct {
 func NewTable(streams userio.IOStreams, showProxy bool) TableEnv {
 	t := table.NewWriter()
 	if showProxy {
-		t.AppendHeader(table.Row{"Name", "ID", "CloudPlatform", "Proxy", "Pid"})
+		t.AppendHeader(table.Row{"Name", "Tier", "ID", "CloudPlatform", "Proxy", "Pid"})
 	} else {
-		t.AppendHeader(table.Row{"Name", "ID", "CloudPlatform"})
+		t.AppendHeader(table.Row{"Name", "Tier", "ID", "CloudPlatform"})
 	}
 	t.Style().Options.DrawBorder = false
 	t.Style().Options.SeparateColumns = false
@@ -28,12 +28,12 @@ func NewTable(streams userio.IOStreams, showProxy bool) TableEnv {
 	return TableEnv{table: t, showProxy: showProxy}
 }
 
-func (t TableEnv) AppendRow(name, id, platform, proxy, pid string) {
+func (t TableEnv) AppendRow(name, tier, id, platform, proxy, pid string) {
 
 	if t.showProxy {
-		t.table.AppendRows([]table.Row{{name, id, platform, proxy, pid}})
+		t.table.AppendRows([]table.Row{{name, tier, id, platform, proxy, pid}})
 	} else {
-		t.table.AppendRows([]table.Row{{name, id, platform}})
+		t.table.AppendRows([]table.Row{{name, tier, id, platform}})
 	}
 
 }
@@ -57,5 +57,5 @@ func (t TableEnv) AppendEnv(env environment.Environment, proxy string, pid strin
 		platform = "AWS"
 	}
 
-	t.AppendRow(env.Environment, id, platform, proxy, pid)
+	t.AppendRow(env.Environment, string(env.Tier), id, platform, proxy, pid)
 }

--- a/pkg/env/list_test.go
+++ b/pkg/env/list_test.go
@@ -20,25 +20,27 @@ func TestAppendEnv(t *testing.T) {
 			name: "GCP environment",
 			env: environment.Environment{
 				Environment: "predev",
+				Tier:        environment.PreDevEnvironmentTier,
 				Platform: &environment.GCPVendor{
 					ProjectId: "gcp-predev-1234",
 				},
 			},
 			expected: `
-NAME    ID               CLOUDPLATFORM 
- predev  gcp-predev-1234  GCP`,
+			NAME    TIER     ID               CLOUDPLATFORM 
+			 predev  pre-dev  gcp-predev-1234  GCP`,
 		},
 		{
 			name: "AWS environment",
 			env: environment.Environment{
 				Environment: "production",
+				Tier:        environment.ProdEnvironmentTier,
 				Platform: &environment.AWSVendor{
 					AccountId: "aws-production-5678",
 				},
 			},
 			expected: `
-NAME        ID                   CLOUDPLATFORM 
- production  aws-production-5678  AWS`,
+			NAME        TIER  ID                   CLOUDPLATFORM 
+			 production  prod  aws-production-5678  AWS`,
 		},
 	}
 
@@ -60,6 +62,7 @@ NAME        ID                   CLOUDPLATFORM
 func TestAppendRow(t *testing.T) {
 	tests := []struct {
 		title    string
+		tier     string
 		platform string
 		name     string
 		id       string
@@ -67,29 +70,32 @@ func TestAppendRow(t *testing.T) {
 	}{
 		{
 			title:    "No rows",
+			tier:     "",
 			platform: "",
 			name:     "",
 			id:       "",
 			expected: `
-NAME  ID  CLOUDPLATFORM`,
+			NAME  TIER  ID  CLOUDPLATFORM`,
 		},
 		{
 			title:    "GCP rows",
+			tier:     "pre-dev",
 			platform: "GCP",
 			name:     "gcpdev-1234",
 			id:       "1234",
 			expected: `
-NAME         ID    CLOUDPLATFORM 
- gcpdev-1234  1234  GCP`,
+			NAME         TIER     ID    CLOUDPLATFORM 
+			 gcpdev-1234  pre-dev  1234  GCP`,
 		},
 		{
 			title:    "AWS rows",
+			tier:     "prod",
 			platform: "AWS",
 			name:     "awsprod-5678",
 			id:       "5678",
 			expected: `
-NAME          ID    CLOUDPLATFORM 
- awsprod-5678  5678  AWS`,
+			NAME          TIER  ID    CLOUDPLATFORM 
+			 awsprod-5678  prod  5678  AWS`,
 		},
 	}
 
@@ -102,7 +108,7 @@ NAME          ID    CLOUDPLATFORM
 	for _, tt := range tests {
 		t.Run(tt.title, func(t *testing.T) {
 			table := NewTable(streams, false)
-			table.AppendRow(tt.name, tt.id, tt.platform, "", "")
+			table.AppendRow(tt.name, tt.tier, tt.id, tt.platform, "", "")
 			compareOutput(t, table.Render(), tt.expected)
 		})
 	}
@@ -110,8 +116,7 @@ NAME          ID    CLOUDPLATFORM
 
 func compareOutput(t *testing.T, out string, expected string) {
 	out = strings.TrimSpace(out)
-	if strings.HasPrefix(expected, "\n") {
-		expected = strings.Replace(expected, "\n", "", 1)
-	}
+	expected = strings.ReplaceAll(expected, "\t", "")
+	expected = strings.TrimSpace(expected)
 	assert.Equal(t, expected, out)
 }

--- a/testdata/repositories/cplatform/environments/dev/config.yaml
+++ b/testdata/repositories/cplatform/environments/dev/config.yaml
@@ -1,6 +1,7 @@
 release: "0.9.0"
 
 environment: "dev"
+tier: "dev"
 domain: "dev.domain"
 
 features:

--- a/testdata/repositories/cplatform/environments/prod/config.yaml
+++ b/testdata/repositories/cplatform/environments/prod/config.yaml
@@ -1,6 +1,7 @@
 release: "0.9.0"
 
 environment: "prod"
+tier: "prod"
 domain: "prod.domain"
 
 features:


### PR DESCRIPTION
## Summary
- update `github.com/coreeng/core-platform/pkg` to `v0.58.0`
- show each environment tier in `corectl env list` and the shared environment table output
- refresh integration fixtures so test environment configs include the required `tier` field
- refresh the Go module checksums after the dependency upgrade

## Verification
- `go test ./pkg/env/...`
- `make test`
- `make build`

## Ticket
- PT-261