### PR TITLE
Bump core-platform package to v0.61.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.60.0
+	github.com/coreeng/core-platform/pkg v0.61.0
 	github.com/go-git/go-billy/v5 v5.8.0
 	github.com/go-git/go-git/v5 v5.18.0
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/T
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/coreeng/core-platform/pkg v0.60.0 h1:25S16wCQNcePZe74U795KU/jB2+8KOzN5prRwULFgCY=
-github.com/coreeng/core-platform/pkg v0.60.0/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
+github.com/coreeng/core-platform/pkg v0.61.0 h1:2rSTglXkQZDGegECeExaJFNzG+dts81AMAnUCSqDGUQ=
+github.com/coreeng/core-platform/pkg v0.61.0/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=


### PR DESCRIPTION
## Summary
- Update `github.com/coreeng/core-platform/pkg` from `v0.60.0` to `v0.61.0`.

## Validation
- `go mod download`
- `make test`
- `make build`