### PR TITLE
Add Homebrew publishing for corectl

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,3 +32,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,3 +38,17 @@ release:
     owner: coreeng
     name: corectl
   mode: append
+
+brews:
+  - name: corectl
+    repository:
+      owner: coreeng
+      name: homebrew-public
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: .
+    homepage: "https://github.com/coreeng/corectl"
+    description: "Core Platform CLI"
+    commit_author:
+      name: goreleaser-bot
+      email: bot@coreeng.io
+    skip_upload: '{{ if .Env.HOMEBREW_TAP_GITHUB_TOKEN }}auto{{ else }}true{{ end }}'

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Interested in learning more about CECG's Core Platform? Book a demo at [Core Pla
 
 # Downloading
 
+Install with Homebrew:
+
+```bash
+brew install coreeng/public/corectl
+```
+
 Releases for Linux and Mac are published in [releases](https://github.com/coreeng/corectl/releases/)
 Download and unzip your platform e.g for Mac with Apple chip download `corectl_Darwin_arm64.tar.gz`
 and add to your path.


### PR DESCRIPTION
## Summary
- add GoReleaser Homebrew formula publishing to coreeng/homebrew-public
- pass HOMEBREW_TAP_GITHUB_TOKEN to the release workflow
- document Homebrew installation in the README

## Validation
- ruby YAML parse for .goreleaser.yaml and .github/workflows/release.yaml
- git diff --check

Note: goreleaser check was not run locally because goreleaser is not installed in this environment.