### PR TITLE
Bump core-platform package to v0.62.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.62.1
+	github.com/coreeng/core-platform/pkg v0.62.2
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/coreeng/core-platform/pkg v0.62.1 h1:ToN7ynovAc3Tt2qnnkyl5zPB+2rFcsZwUDttORUrDrc=
-github.com/coreeng/core-platform/pkg v0.62.1/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
+github.com/coreeng/core-platform/pkg v0.62.2 h1:cnriMuBd9wqWlj1PVxbv37D+EVHoea+egzNuMo6yHUc=
+github.com/coreeng/core-platform/pkg v0.62.2/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=


### PR DESCRIPTION
## Summary
- Update github.com/coreeng/core-platform/pkg from v0.62.1 to v0.62.2
- Refresh go.sum checksums via go mod tidy

## Tests
- go test ./pkg/...