### PR TITLE
Bump core-platform package to v0.64.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.63.1
+	github.com/coreeng/core-platform/pkg v0.64.0
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/coreeng/core-platform/pkg v0.63.1 h1:8xPfaspyA/RzMwnvUbGkJBiH33CPX/acqFTCcq1Y+jQ=
-github.com/coreeng/core-platform/pkg v0.63.1/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
+github.com/coreeng/core-platform/pkg v0.64.0 h1:V9Xl6ELRmSXoTA6jyU8UyQYPwgK6uTe3WgwjZBl1Hhg=
+github.com/coreeng/core-platform/pkg v0.64.0/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.7.0 h1:s0Y3ITPy6sQn5xt54DuYvTF8hu134ooYLUb58DX/HjE=
 github.com/cyphar/filepath-securejoin v0.7.0/go.mod h1:ymLGms/u3BYaviIiuKFnUx8EkQEZeK6cInNoAPJA3o4=


### PR DESCRIPTION
## Summary
- bump github.com/coreeng/core-platform/pkg from v0.63.1 to v0.64.0
- consume the tenant validation change that removes duplicate group warning/error enforcement