### PR TITLE
Enable GitHub branch protection in new app repositories by default

### DIFF
--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -39,19 +39,20 @@ func NewService(templateRenderer render.TemplateRenderer, githubClient *github.C
 }
 
 type CreateOp struct {
-	Name             string
-	GitHubRepoName   string
-	Description      string
-	OrgName          string
-	LocalPath        string
-	Tenant           *coretnt.Tenant
-	FastFeedbackEnvs []environment.Environment
-	ExtendedTestEnvs []environment.Environment
-	ProdEnvs         []environment.Environment
-	Template         *template.Spec
-	GitAuth          git.AuthMethod
-	Config           string
-	Public           bool
+	Name                 string
+	GitHubRepoName       string
+	Description          string
+	OrgName              string
+	LocalPath            string
+	Tenant               *coretnt.Tenant
+	FastFeedbackEnvs     []environment.Environment
+	ExtendedTestEnvs     []environment.Environment
+	ProdEnvs             []environment.Environment
+	Template             *template.Spec
+	GitAuth              git.AuthMethod
+	Config               string
+	Public               bool
+	SkipBranchProtection bool
 }
 
 type CreateResult struct {
@@ -133,6 +134,11 @@ func (svc *Service) handleSingleRepo(op CreateOp, localRepo *git.LocalRepository
 		Auth: op.GitAuth,
 	}); err != nil {
 		return result, err
+	}
+	if !op.SkipBranchProtection {
+		if err := svc.protectDefaultBranch(op, repoFullId); err != nil {
+			return result, err
+		}
 	}
 
 	return CreateResult{
@@ -416,6 +422,50 @@ func (svc *Service) createGithubRepository(op CreateOp) (*github.Repository, err
 		repo.CloneURL = github.String(fmt.Sprintf("https://github.com/%s/%s.git", *repo.Owner.Login, *repo.Name))
 		return &repo, nil
 	}
+}
+
+func (svc *Service) protectDefaultBranch(op CreateOp, repoFullId git.GithubRepoFullId) error {
+	logger.Info().With(
+		zap.String("name", op.Name),
+		zap.String("org", repoFullId.Organization()),
+		zap.String("repo", repoFullId.Name()),
+		zap.String("branch", git.MainBranch),
+		zap.Bool("dry_run", svc.DryRun),
+	).Msg("github: protecting default branch")
+
+	if svc.DryRun {
+		return nil
+	}
+
+	disabled := false
+	enabled := true
+	contexts := []string{}
+	lastPushApproval := true
+	_, _, err := svc.GithubClient.Repositories.UpdateBranchProtection(
+		context.Background(),
+		repoFullId.Organization(),
+		repoFullId.Name(),
+		git.MainBranch,
+		&github.ProtectionRequest{
+			RequiredStatusChecks: &github.RequiredStatusChecks{
+				Strict:   false,
+				Contexts: &contexts,
+			},
+			EnforceAdmins: true,
+			RequiredPullRequestReviews: &github.PullRequestReviewsEnforcementRequest{
+				DismissStaleReviews:          true,
+				RequireCodeOwnerReviews:      false,
+				RequiredApprovingReviewCount: 1,
+				RequireLastPushApproval:      &lastPushApproval,
+			},
+			Restrictions:                   nil,
+			RequireLinearHistory:           &disabled,
+			AllowForcePushes:               &disabled,
+			AllowDeletions:                 &disabled,
+			RequiredConversationResolution: &enabled,
+		},
+	)
+	return err
 }
 
 func (svc *Service) synchronizeRepository(op CreateOp, repoFullId git.GithubRepoFullId) error {

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -28,6 +28,11 @@ var postRepositoriesEnvironmentsVariablesByRepositoryIDByEnvironmentName = mock.
 	Method:  "POST",
 }
 
+var putReposBranchesProtectionByOwnerByRepoByBranch = mock.EndpointPattern{
+	Pattern: "/repos/{owner}/{repo}/branches/{branch}/protection",
+	Method:  "PUT",
+}
+
 var _ = Describe("Create new application", func() {
 	t := GinkgoTB()
 
@@ -44,13 +49,14 @@ var _ = Describe("Create new application", func() {
 		devEnv        environment.Environment
 		prodEnv       environment.Environment
 
-		createRepoCapture    *httpmock.HttpCaptureHandler[github.Repository]
-		createRepoVarCapture *httpmock.HttpCaptureHandler[httpmock.ActionVariableRequest]
-		createEnvCapture     *httpmock.HttpCaptureHandler[httpmock.CreateUpdateEnvRequest]
-		createEnvVarCapture  *httpmock.HttpCaptureHandler[httpmock.ActionEnvVariableRequest]
-		githubClient         *github.Client
-		renderer             *render.StubTemplateRenderer
-		service              *Service
+		createRepoCapture       *httpmock.HttpCaptureHandler[github.Repository]
+		createRepoVarCapture    *httpmock.HttpCaptureHandler[httpmock.ActionVariableRequest]
+		createEnvCapture        *httpmock.HttpCaptureHandler[httpmock.CreateUpdateEnvRequest]
+		createEnvVarCapture     *httpmock.HttpCaptureHandler[httpmock.ActionEnvVariableRequest]
+		branchProtectionCapture *httpmock.HttpCaptureHandler[github.ProtectionRequest]
+		githubClient            *github.Client
+		renderer                *render.StubTemplateRenderer
+		service                 *Service
 	)
 	BeforeEach(OncePerOrdered, func() {
 		newRepoId = 1234
@@ -106,6 +112,9 @@ var _ = Describe("Create new application", func() {
 		createRepoVarCapture = httpmock.NewCreateActionVariablesCapture()
 		createEnvCapture = httpmock.NewCreateUpdateEnvCapture()
 		createEnvVarCapture = httpmock.NewCreateActionEnvVariablesCapture()
+		branchProtectionCapture = httpmock.NewCaptureHandler[github.ProtectionRequest](
+			&github.Protection{},
+		)
 
 		githubClient = github.NewClient(mock.NewMockedHTTPClient(
 			mock.WithRequestMatchHandler(
@@ -123,6 +132,10 @@ var _ = Describe("Create new application", func() {
 			mock.WithRequestMatchHandler(
 				postRepositoriesEnvironmentsVariablesByRepositoryIDByEnvironmentName,
 				createEnvVarCapture.Func(),
+			),
+			mock.WithRequestMatchHandler(
+				putReposBranchesProtectionByOwnerByRepoByBranch,
+				branchProtectionCapture.Func(),
 			),
 		))
 		Expect(cplatformServerRepo)
@@ -188,6 +201,30 @@ var _ = Describe("Create new application", func() {
 				return v.Org == githubOrg &&
 					v.RepoName == newAppName
 			})))
+		})
+		It("protected default branch in new repo", func() {
+			Expect(branchProtectionCapture.Requests).To(HaveLen(1))
+			request := branchProtectionCapture.Requests[0]
+			Expect(request.EnforceAdmins).To(BeTrue())
+			Expect(request.RequiredStatusChecks).NotTo(BeNil())
+			Expect(request.RequiredStatusChecks.Strict).To(BeFalse())
+			Expect(request.RequiredStatusChecks.Contexts).NotTo(BeNil())
+			Expect(*request.RequiredStatusChecks.Contexts).To(BeEmpty())
+			Expect(request.RequiredPullRequestReviews).NotTo(BeNil())
+			Expect(request.RequiredPullRequestReviews.DismissStaleReviews).To(BeTrue())
+			Expect(request.RequiredPullRequestReviews.RequireCodeOwnerReviews).To(BeFalse())
+			Expect(request.RequiredPullRequestReviews.RequiredApprovingReviewCount).To(Equal(1))
+			Expect(request.RequiredPullRequestReviews.RequireLastPushApproval).NotTo(BeNil())
+			Expect(*request.RequiredPullRequestReviews.RequireLastPushApproval).To(BeTrue())
+			Expect(request.Restrictions).To(BeNil())
+			Expect(request.RequireLinearHistory).NotTo(BeNil())
+			Expect(*request.RequireLinearHistory).To(BeFalse())
+			Expect(request.AllowForcePushes).NotTo(BeNil())
+			Expect(*request.AllowForcePushes).To(BeFalse())
+			Expect(request.AllowDeletions).NotTo(BeNil())
+			Expect(*request.AllowDeletions).To(BeFalse())
+			Expect(request.RequiredConversationResolution).NotTo(BeNil())
+			Expect(*request.RequiredConversationResolution).To(BeTrue())
 		})
 		It("created environments in new repo", func() {
 			Expect(createEnvCapture.Requests).To(ConsistOf(
@@ -341,6 +378,35 @@ var _ = Describe("Create new application", func() {
 
 	})
 
+	Context("with branch protection skipped", Ordered, func() {
+		BeforeAll(func() {
+			renderer = &render.StubTemplateRenderer{
+				Renderer: &render.FlagsAwareTemplateRenderer{},
+			}
+			service = NewService(renderer, githubClient, false)
+			templateToUse, err := template.FindByName(configpath.GetCorectlTemplatesDir(), testdata.BlankTemplate())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = service.Create(CreateOp{
+				Name:                 "new-app-name",
+				GitHubRepoName:       "",
+				OrgName:              "github-org-name",
+				LocalPath:            t.TempDir(),
+				Tenant:               defaultTenant,
+				FastFeedbackEnvs:     []environment.Environment{devEnv},
+				ExtendedTestEnvs:     []environment.Environment{devEnv},
+				ProdEnvs:             []environment.Environment{prodEnv},
+				Template:             templateToUse,
+				SkipBranchProtection: true,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("does not protect the default branch", func() {
+			Expect(branchProtectionCapture.Requests).To(BeEmpty())
+		})
+	})
+
 	Context("from template with public visibility", Ordered, func() {
 		var (
 			createPublicRepoCapture *httpmock.HttpCaptureHandler[github.Repository]
@@ -377,6 +443,10 @@ var _ = Describe("Create new application", func() {
 				mock.WithRequestMatchHandler(
 					postRepositoriesEnvironmentsVariablesByRepositoryIDByEnvironmentName,
 					createEnvVarCapture.Func(),
+				),
+				mock.WithRequestMatchHandler(
+					putReposBranchesProtectionByOwnerByRepoByBranch,
+					branchProtectionCapture.Func(),
 				),
 			))
 

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -29,19 +29,20 @@ import (
 )
 
 type AppCreateOpt struct {
-	Name           string
-	LocalPath      string
-	FromTemplate   string
-	Tenant         string
-	GitHubRepoName string
-	Description    string
-	Prefix         string
-	ArgsFile       string
-	Args           []string
-	Config         string
-	DryRun         bool
-	Public         bool
-	CloudAccess    bool
+	Name                 string
+	LocalPath            string
+	FromTemplate         string
+	Tenant               string
+	GitHubRepoName       string
+	Description          string
+	Prefix               string
+	ArgsFile             string
+	Args                 []string
+	Config               string
+	DryRun               bool
+	Public               bool
+	CloudAccess          bool
+	SkipBranchProtection bool
 
 	Streams userio.IOStreams
 }
@@ -160,6 +161,12 @@ NOTE:
 		"cloud-access",
 		false,
 		"Configure GCP cloud access for the generated delivery unit",
+	)
+	appCreateCmd.Flags().BoolVar(
+		&opts.SkipBranchProtection,
+		"skip-branch-protection",
+		false,
+		"Skip applying default branch protection to the created GitHub repository",
 	)
 
 	config.RegisterBoolParameterAsFlag(
@@ -370,19 +377,20 @@ func createNewApp(
 		newAppOrg = cfg.GitHub.Organization.Value
 	}
 	createOp := application.CreateOp{
-		Name:             opts.Name,
-		GitHubRepoName:   opts.GitHubRepoName,
-		Description:      opts.Description,
-		OrgName:          newAppOrg,
-		LocalPath:        opts.LocalPath,
-		Tenant:           appTenant,
-		FastFeedbackEnvs: fastFeedbackEnvs,
-		ExtendedTestEnvs: extendedTestEnvs,
-		ProdEnvs:         prodEnvs,
-		Template:         fromTemplate,
-		GitAuth:          gitAuth,
-		Config:           opts.Config,
-		Public:           opts.Public,
+		Name:                 opts.Name,
+		GitHubRepoName:       opts.GitHubRepoName,
+		Description:          opts.Description,
+		OrgName:              newAppOrg,
+		LocalPath:            opts.LocalPath,
+		Tenant:               appTenant,
+		FastFeedbackEnvs:     fastFeedbackEnvs,
+		ExtendedTestEnvs:     extendedTestEnvs,
+		ProdEnvs:             prodEnvs,
+		Template:             fromTemplate,
+		GitAuth:              gitAuth,
+		Config:               opts.Config,
+		Public:               opts.Public,
+		SkipBranchProtection: opts.SkipBranchProtection,
 	}
 	if err := service.ValidateCreate(createOp); err != nil {
 		return application.CreateResult{}, err


### PR DESCRIPTION
## Summary
- apply classic branch protection to newly created single-repo applications by default
- add `--skip-branch-protection` to opt out when creating an application repo
- cover default and skipped branch protection behavior in application creation tests

## Testing
- `go test ./pkg/application`
- `go test ./pkg/cmd/application/create`
- `go test ./pkg/cmd/application/... ./pkg/application`
- `go test ./...` fails only for integration/localintegration packages because `TEST_CORECTL_BINARY` is not set