### PR TITLE
Log Homebrew tap token owner

### DIFF
--- a/.github/workflows/identify-homebrew-token-owner.yaml
+++ b/.github/workflows/identify-homebrew-token-owner.yaml
@@ -1,0 +1,17 @@
+name: Identify Homebrew Token Owner
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  identify:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: identify-homebrew-token-owner
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          gh api /user --jq '"HOMEBREW_TAP_GITHUB_TOKEN owner: \(.login) (\(.type), id=\(.id))"'


### PR DESCRIPTION
## Summary
- add a release workflow step that identifies the GitHub account behind `HOMEBREW_TAP_GITHUB_TOKEN`
- print only the token owner login, type, and id; the secret value is not exposed

## Context
The corectl v0.65.1 release failed updating `coreeng/homebrew-public` because branch protection requires changes through PRs. We need the token owner so we can add a narrowly scoped branch-protection bypass for release automation.

## Testing
- workflow-only change; not run locally