### PR TITLE
Use core-platform-infra Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/coreeng/core-platform/pkg v0.65.4
+	github.com/coreeng/core-platform-infra/pkg v0.66.0
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-git/go-git/v5 v5.19.1
 	github.com/google/go-github/v60 v60.0.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
 github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/coreeng/core-platform/pkg v0.65.4 h1:ZcBx6pkWvC1K8MInRlccSjQKvtHegxd8NKQkiiiAEKM=
-github.com/coreeng/core-platform/pkg v0.65.4/go.mod h1:sMlX1pv+qVkTmXynnCpwgQWkGY3uXvc+XOHK6We1hTw=
+github.com/coreeng/core-platform-infra/pkg v0.66.0 h1:eDfoeDs0EJbXiJ96br6BpYGiH7fOVuisL/vGi4nrnm8=
+github.com/coreeng/core-platform-infra/pkg v0.66.0/go.mod h1:/llwaVMNDLG0V44Ff7bkK7iXUYMHN8bPShxPeNIq1jk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/cyphar/filepath-securejoin v0.7.0 h1:s0Y3ITPy6sQn5xt54DuYvTF8hu134ooYLUb58DX/HjE=
 github.com/cyphar/filepath-securejoin v0.7.0/go.mod h1:ymLGms/u3BYaviIiuKFnUx8EkQEZeK6cInNoAPJA3o4=
@@ -262,8 +262,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
-github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rogpeppe/go-internal v1.15.0 h1:D0RCU5rMAp+SpgkiNdrjfJ+LX4J1M32V2NeCY7EJ6hc=
+github.com/rogpeppe/go-internal v1.15.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sahilm/fuzzy v0.1.3 h1:juByESSS32nVD81vr6tHmKmA/8zde7gE+x5CLxrzXPU=
 github.com/sahilm/fuzzy v0.1.3/go.mod h1:au6//VbVSqu6DFrkL2CfjlJ5iURpNCPeE+1GwY3XsT8=

--- a/pkg/application/create.go
+++ b/pkg/application/create.go
@@ -10,9 +10,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	"github.com/coreeng/core-platform/pkg/p2p"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/p2p"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmd/template/render"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/git"

--- a/pkg/application/create_test.go
+++ b/pkg/application/create_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmd/template/render"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/template"

--- a/pkg/application/validate_create_test.go
+++ b/pkg/application/validate_create_test.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/application"
 	"github.com/coreeng/corectl/pkg/testutil/gittest"
 	"github.com/coreeng/corectl/pkg/testutil/httpmock"

--- a/pkg/cmd/application/create/app_create.go
+++ b/pkg/cmd/application/create/app_create.go
@@ -13,8 +13,8 @@ import (
 	"github.com/coreeng/corectl/pkg/logger"
 	"go.uber.org/zap"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/application"
 	"github.com/coreeng/corectl/pkg/cmd/template/render"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"

--- a/pkg/cmd/application/create/app_create_test.go
+++ b/pkg/cmd/application/create/app_create_test.go
@@ -3,8 +3,8 @@ package create
 import (
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"

--- a/pkg/cmd/env/active.go
+++ b/pkg/cmd/env/active.go
@@ -3,7 +3,7 @@ package env
 import (
 	"fmt"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"

--- a/pkg/cmd/env/connect.go
+++ b/pkg/cmd/env/connect.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/command"

--- a/pkg/cmd/env/disconnect.go
+++ b/pkg/cmd/env/disconnect.go
@@ -6,7 +6,7 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"os"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/command"

--- a/pkg/cmd/env/list.go
+++ b/pkg/cmd/env/list.go
@@ -2,7 +2,7 @@ package env
 
 import (
 	"fmt"
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"

--- a/pkg/cmd/env/open.go
+++ b/pkg/cmd/env/open.go
@@ -5,7 +5,7 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"strings"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	corectlenv "github.com/coreeng/corectl/pkg/env"

--- a/pkg/cmd/p2p/env/sync/env_sync.go
+++ b/pkg/cmd/p2p/env/sync/env_sync.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 
-	corep2p "github.com/coreeng/core-platform/pkg/p2p"
+	corep2p "github.com/coreeng/core-platform-infra/pkg/p2p"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/git"

--- a/pkg/cmd/tenant/create/tenant_create.go
+++ b/pkg/cmd/tenant/create/tenant_create.go
@@ -12,8 +12,8 @@ import (
 	"github.com/coreeng/corectl/pkg/logger"
 	"go.uber.org/zap"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/git"

--- a/pkg/cmd/tenant/create/tenant_create_test.go
+++ b/pkg/cmd/tenant/create/tenant_create_test.go
@@ -3,8 +3,8 @@ package create
 import (
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/pkg/cmd/tenant/describe/tenant_describe.go
+++ b/pkg/cmd/tenant/describe/tenant_describe.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/spf13/cobra"

--- a/pkg/cmd/tenant/list/tenant_list.go
+++ b/pkg/cmd/tenant/list/tenant_list.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	corectltnt "github.com/coreeng/corectl/pkg/tenant"

--- a/pkg/cmd/tenant/setrepo/tenant_set_repo.go
+++ b/pkg/cmd/tenant/setrepo/tenant_set_repo.go
@@ -3,7 +3,7 @@ package setrepo
 import (
 	"fmt"
 
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"

--- a/pkg/cmd/tenant/tree/tenant_tree.go
+++ b/pkg/cmd/tenant/tree/tenant_tree.go
@@ -3,7 +3,7 @@ package tree
 import (
 	"fmt"
 
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"

--- a/pkg/cmdutil/selector/input.go
+++ b/pkg/cmdutil/selector/input.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 )
 

--- a/pkg/cmdutil/selector/input_test.go
+++ b/pkg/cmdutil/selector/input_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/testutil/gittest"

--- a/pkg/cmdutil/userio/input_source_switch.go
+++ b/pkg/cmdutil/userio/input_source_switch.go
@@ -3,7 +3,7 @@ package userio
 import (
 	"errors"
 	"fmt"
-	"github.com/coreeng/core-platform/pkg/validator"
+	"github.com/coreeng/core-platform-infra/pkg/validator"
 )
 
 var (

--- a/pkg/env/connect.go
+++ b/pkg/env/connect.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/cedws/iapc/iap"
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/command"
 	"github.com/coreeng/corectl/pkg/gcp"

--- a/pkg/env/connect_test.go
+++ b/pkg/env/connect_test.go
@@ -5,7 +5,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/coreeng/corectl/pkg/command"
 	"github.com/stretchr/testify/assert"

--- a/pkg/env/list.go
+++ b/pkg/env/list.go
@@ -1,7 +1,7 @@
 package env
 
 import (
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/jedib0t/go-pretty/v6/table"
 )

--- a/pkg/env/list_test.go
+++ b/pkg/env/list_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/stretchr/testify/assert"
 )

--- a/pkg/env/resources.go
+++ b/pkg/env/resources.go
@@ -3,7 +3,7 @@ package env
 import (
 	"errors"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 )
 
 var (

--- a/pkg/env/util.go
+++ b/pkg/env/util.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/logger"
 	"github.com/shirou/gopsutil/v3/process"
 )

--- a/pkg/env/validate.go
+++ b/pkg/env/validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreeng/corectl/pkg/command"
 	"strings"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/gcp"
 )
 

--- a/pkg/env/validate_test.go
+++ b/pkg/env/validate_test.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/gcp"
 	gcptest "github.com/coreeng/corectl/pkg/testutil/gcp"
 	"github.com/stretchr/testify/assert"

--- a/pkg/p2p/cleaning.go
+++ b/pkg/p2p/cleaning.go
@@ -2,8 +2,8 @@ package p2p
 
 import (
 	"context"
-	"github.com/coreeng/core-platform/pkg/environment"
-	"github.com/coreeng/core-platform/pkg/p2p"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/p2p"
 	"github.com/google/go-github/v60/github"
 	"slices"
 )

--- a/pkg/p2p/env_variables.go
+++ b/pkg/p2p/env_variables.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/git"
 )
 

--- a/pkg/p2p/env_variables_test.go
+++ b/pkg/p2p/env_variables_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coreeng/core-platform/pkg/environment"
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/testutil/gittest"
 	"github.com/coreeng/corectl/testdata"

--- a/pkg/tenant/list.go
+++ b/pkg/tenant/list.go
@@ -1,7 +1,7 @@
 package tenant
 
 import (
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	"github.com/jedib0t/go-pretty/v6/table"
 )

--- a/pkg/tenant/list_test.go
+++ b/pkg/tenant/list_test.go
@@ -3,7 +3,7 @@ package tenant
 import (
 	"bytes"
 
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/cmdutil/userio"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/tenant/tree.go
+++ b/pkg/tenant/tree.go
@@ -3,7 +3,7 @@ package tenant
 import (
 	"fmt"
 
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 )
 
 type Node struct {

--- a/pkg/tenant/tree_test.go
+++ b/pkg/tenant/tree_test.go
@@ -3,7 +3,7 @@ package tenant
 import (
 	"testing"
 
-	coretnt "github.com/coreeng/core-platform/pkg/tenant"
+	coretnt "github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/tenant/write.go
+++ b/pkg/tenant/write.go
@@ -5,7 +5,7 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"path/filepath"
 
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/logger"
 	"github.com/google/go-github/v60/github"

--- a/pkg/tenant/write_test.go
+++ b/pkg/tenant/write_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/coreeng/core-platform/pkg/tenant"
+	"github.com/coreeng/core-platform-infra/pkg/tenant"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/pkg/testutil/gittest"
 	"github.com/coreeng/corectl/pkg/testutil/httpmock"

--- a/tests/integration/application/application.go
+++ b/tests/integration/application/application.go
@@ -9,7 +9,7 @@ import (
 
 	"time"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/git"

--- a/tests/integration/p2p/export.go
+++ b/tests/integration/p2p/export.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/pkg/git"
 	"github.com/coreeng/corectl/testdata"

--- a/tests/integration/p2p/p2p.go
+++ b/tests/integration/p2p/p2p.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coreeng/corectl/pkg/cmdutil/configpath"
 	"github.com/coreeng/corectl/pkg/git"
 
-	"github.com/coreeng/core-platform/pkg/environment"
+	"github.com/coreeng/core-platform-infra/pkg/environment"
 	"github.com/coreeng/corectl/pkg/cmdutil/config"
 	"github.com/coreeng/corectl/testdata"
 	"github.com/coreeng/corectl/tests/integration/testconfig"


### PR DESCRIPTION
## Summary
- replace the retired `github.com/coreeng/core-platform/pkg` dependency
- use `github.com/coreeng/core-platform-infra/pkg v0.66.0` throughout

## Verification
- clean direct module download
- `make lint test build`